### PR TITLE
Auto Scaling

### DIFF
--- a/vnc.html
+++ b/vnc.html
@@ -145,9 +145,14 @@
                     <li><input id="noVNC_encrypt" type="checkbox"> Encrypt</li>
                     <li><input id="noVNC_true_color" type="checkbox" checked> True Color</li>
                     <li><input id="noVNC_cursor" type="checkbox"> Local Cursor</li>
-                    <li><input id="noVNC_clip" type="checkbox"> Clip to Window</li>
                     <li><input id="noVNC_shared" type="checkbox"> Shared Mode</li>
                     <li><input id="noVNC_view_only" type="checkbox"> View Only</li>
+                    <li>&nbsp;</li>
+                    <li> Resize using:</li>
+                    <!--li><input id="noVNC_fullsize" name="noVNC_clip" type="radio" value="true"> Fullsize</li-->
+                    <li><input id="noVNC_clip" name="noVNC_clip" type="radio" value="true"> Clip to Window</li>
+                    <li><input id="noVNC_scale" name="noVNC_clip" type="radio" value="true" checked="checked"> Scale to Window</li>
+                    <li>&nbsp;</li>
                     <li><input id="noVNC_connectTimeout" type="input"> Connect Timeout (s)</li>
                     <li><input id="noVNC_path" type="input" value="websockify"> Path</li>
                     <li><input id="noVNC_repeaterID" type="input" value=""> Repeater ID</li>

--- a/vnc_auto.html
+++ b/vnc_auto.html
@@ -160,6 +160,7 @@
                            'true_color':   WebUtil.getQueryVar('true_color', true),
                            'local_cursor': WebUtil.getQueryVar('cursor', true),
                            'shared':       WebUtil.getQueryVar('shared', true),
+                           'scale':       WebUtil.getQueryVar('scale', true),
                            'view_only':    WebUtil.getQueryVar('view_only', false),
                            'updateState':  updateState,
                            'onPasswordRequired':  passwordRequired});


### PR DESCRIPTION
Config options aren't implemented and there are rough edges but auto scaling to max possible size should work for vnc.html and vnc_auto.html.

Tested on Chrome16/ Ipad2(IOS5) /Iphone3 (IOS4).

I figured you probably wouldn't want it just like this so it's more of a demo of what's possible.
Not tested with flash or other weirdness.

Scaling of type "fit" which uses all available width/height can't be implemented until scaling functions for the mouse have separate scaling values for x/y.