### PR TITLE
Disable IME while noVNC is working

### DIFF
--- a/include/base.css
+++ b/include/base.css
@@ -129,6 +129,7 @@ html {
   background-color:#313131;
   border-bottom-right-radius: 800px 600px;
   /*border-top-left-radius: 800px 600px;*/
+  imeMode: disabled;
 }
 
 #noVNC_container, #noVNC_canvas {

--- a/include/base.css
+++ b/include/base.css
@@ -129,7 +129,7 @@ html {
   background-color:#313131;
   border-bottom-right-radius: 800px 600px;
   /*border-top-left-radius: 800px 600px;*/
-  imeMode: disabled;
+  ime-mode: disabled;
 }
 
 #noVNC_container, #noVNC_canvas {


### PR DESCRIPTION
IME -- Input Method Editor -- will intercept all the key events and make some of the events broken.
With this patch, IME is automatically disabled when noVNC gets the focus, and you don't have to worry if some key strokes happen to activate IME again.

This patch only works for IE, FireFox and Opera. But there is no harm for Chrome and Safari.
Even after applying this patch, if you want to use Chrome or Safari, or you have overwritten the css, you need to turn off IME manually.

