### PR TITLE
Fixing ReferenceError errors

### DIFF
--- a/include/input.js
+++ b/include/input.js
@@ -653,7 +653,7 @@ return that;  // Return the public API interface
 /*
  * Browser keypress to X11 keysym for Unicode characters > U+00FF
  */
-unicodeTable = {
+var unicodeTable = {
     0x0104 : 0x01a1,
     0x02D8 : 0x01a2,
     0x0141 : 0x01a3,

--- a/include/websock.js
+++ b/include/websock.js
@@ -25,6 +25,7 @@
 // To enable WebSocket emulator debug:
 //window.WEB_SOCKET_DEBUG=1;
 
+var Websock_native;
 if (window.WebSocket && !window.WEB_SOCKET_FORCE_FLASH) {
     Websock_native = true;
 } else if (window.MozWebSocket && !window.WEB_SOCKET_FORCE_FLASH) {


### PR DESCRIPTION
Yet Reference Error errors like #194, #202, etc.

As a rule of thumb, initialize your var before declaring or using it.

:+1: 