### PR TITLE
Allow specifying a custom default cursor

### DIFF
--- a/include/display.js
+++ b/include/display.js
@@ -55,7 +55,8 @@ Util.conf_defaults(conf, that, defaults, [
     ['render_mode', 'ro', 'str', '', 'Canvas rendering mode (read-only)'],
 
     ['prefer_js',   'rw', 'str', null, 'Prefer Javascript over canvas methods'],
-    ['cursor_uri',  'rw', 'raw', null, 'Can we render cursor using data URI']
+    ['cursor_uri',  'rw', 'raw', null, 'Can we render cursor using data URI'],
+    ['default_cursor', 'wo', 'str', null, 'Default cursor']
     ]);
 
 // Override some specific getters/setters
@@ -648,7 +649,7 @@ that.changeCursor = function(pixels, mask, hotx, hoty, w, h) {
 };
 
 that.defaultCursor = function() {
-    conf.target.style.cursor = "default";
+    conf.target.style.cursor = conf.default_cursor;
 };
 
 return constructor();  // Return the public API interface

--- a/include/rfb.js
+++ b/include/rfb.js
@@ -142,6 +142,8 @@ Util.conf_defaults(conf, that, defaults, [
     ['connectTimeout',     'rw', 'int', def_con_timeout, 'Time (s) to wait for connection'],
     ['disconnectTimeout',  'rw', 'int', 3,    'Time (s) to wait for disconnection'],
 
+    ['default_cursor',     'wo', 'str', 'default', 'Default cursor'],
+
     // UltraVNC repeater ID to connect to
     ['repeaterID',         'rw', 'str',  '',    'RepeaterID to connect to'],
 
@@ -214,7 +216,7 @@ function constructor() {
     }
     // Initialize display, mouse, keyboard, and websock
     try {
-        display   = new Display({'target': conf.target});
+        display   = new Display({'target': conf.target, 'default_cursor': conf.default_cursor});
     } catch (exc) {
         Util.Error("Display exception: " + exc);
         updateState('fatal', "No working Display");


### PR DESCRIPTION
Makes it possible to specify a default cursor when you create the RFB object.

When Local Cursor is disabled (or unsupported), most VNC clients change the client-side cursor to a dot. With this commit, something similar can be easily done with noVNC in browsers that don't support Local Cursor.