### PR TITLE
Issue#311: Can't show Chinese VM name correctly

### DIFF
--- a/include/rfb.js
+++ b/include/rfb.js
@@ -919,7 +919,7 @@ init_msg = function() {
 
         /* Connection name/title */
         name_length   = ws.rQshift32();
-        fb_name = Util.decodeUTF8(ws.rQshiftUStr(name_length));
+        fb_name = Util.decodeUTF8(ws.rQshiftUTFStr(name_length));
         conf.onDesktopName(that, fb_name);
         
         if (conf.true_color && fb_name === "Intel(r) AMT KVM")

--- a/include/rfb.js
+++ b/include/rfb.js
@@ -919,7 +919,7 @@ init_msg = function() {
 
         /* Connection name/title */
         name_length   = ws.rQshift32();
-        fb_name = Util.decodeUTF8(ws.rQshiftStr(name_length));
+        fb_name = Util.decodeUTF8(ws.rQshiftUStr(name_length));
         conf.onDesktopName(that, fb_name);
         
         if (conf.true_color && fb_name === "Intel(r) AMT KVM")

--- a/include/websock.js
+++ b/include/websock.js
@@ -121,6 +121,46 @@ function rQshiftStr(len) {
     rQi += len;
     return String.fromCharCode.apply(null, arr);
 }
+function rQshiftUTFStr(len) {
+    if (typeof(len) === 'undefined') { len = rQlen(); }
+    var arr = [];
+    for(var i = rQi; i < rQi + len; i++) {
+        var code = rQ[i];
+        // 1-byte
+        if(code <= 0x7f) {
+            arr.push(code);
+            continue;
+        }
+        // 2-byte
+        if(code <= 0xdf) {
+            var sec = rQ[++i];
+            code = ((code & 0x1c) << 6) | (sec & 0x3f);
+            arr.push(code);
+            continue;
+        }
+        // 3-byte
+        if(code <= 0xef) {
+            var sec = rQ[++i];
+            var thi = rQ[++i];
+            code = ((((code & 0xf) << 4) | ((sec & 0x3c) >> 2)) << 8) | (((sec & 0x3) << 6) | (thi & 0x3f));
+            arr.push(code);
+            continue;
+        }
+        // 4-byte
+        if(code <= 0xf7) {
+            var sec = rQ[++i];
+            var thi = rQ[++i];
+            var fou = rQ[++i];
+            var z = ((code & 0x7) << 2) | ((sec & 0x30) >> 4);
+            var y = ((sec & 0xf) << 4) | ((thi & 0x3c) >> 2);
+            var x = ((thi & 0x3) << 6) | (fou & 0x 3f);
+            code = (z << 16) | (y << 8) | x;
+            arr.push(code);
+        }
+    }
+    rQi += len;
+    return String.fromCharCode.apply(null, arr);
+}
 function rQshiftBytes(len) {
     if (typeof(len) === 'undefined') { len = rQlen(); }
     rQi += len;
@@ -400,6 +440,7 @@ function constructor() {
     api.rQshift16    = rQshift16;
     api.rQshift32    = rQshift32;
     api.rQshiftStr   = rQshiftStr;
+    api.rQshiftUStr  = rQshiftUTFStr;
     api.rQshiftBytes = rQshiftBytes;
     api.rQslice      = rQslice;
     api.rQwait       = rQwait;

--- a/include/websock.js
+++ b/include/websock.js
@@ -153,7 +153,7 @@ function rQshiftUTFStr(len) {
             var fou = rQ[++i];
             var z = ((code & 0x7) << 2) | ((sec & 0x30) >> 4);
             var y = ((sec & 0xf) << 4) | ((thi & 0x3c) >> 2);
-            var x = ((thi & 0x3) << 6) | (fou & 0x 3f);
+            var x = ((thi & 0x3) << 6) | (fou & 0x3f);
             code = (z << 16) | (y << 8) | x;
             arr.push(code);
         }
@@ -427,33 +427,33 @@ function constructor() {
     api.maxBufferedAmount = 200;
 
     // Direct access to send and receive queues
-    api.get_sQ       = get_sQ;
-    api.get_rQ       = get_rQ;
-    api.get_rQi      = get_rQi;
-    api.set_rQi      = set_rQi;
+    api.get_sQ        = get_sQ;
+    api.get_rQ        = get_rQ;
+    api.get_rQi       = get_rQi;
+    api.set_rQi       = set_rQi;
 
     // Routines to read from the receive queue
-    api.rQlen        = rQlen;
-    api.rQpeek8      = rQpeek8;
-    api.rQshift8     = rQshift8;
-    api.rQunshift8   = rQunshift8;
-    api.rQshift16    = rQshift16;
-    api.rQshift32    = rQshift32;
-    api.rQshiftStr   = rQshiftStr;
-    api.rQshiftUStr  = rQshiftUTFStr;
-    api.rQshiftBytes = rQshiftBytes;
-    api.rQslice      = rQslice;
-    api.rQwait       = rQwait;
+    api.rQlen         = rQlen;
+    api.rQpeek8       = rQpeek8;
+    api.rQshift8      = rQshift8;
+    api.rQunshift8    = rQunshift8;
+    api.rQshift16     = rQshift16;
+    api.rQshift32     = rQshift32;
+    api.rQshiftStr    = rQshiftStr;
+    api.rQshiftUTFStr = rQshiftUTFStr;
+    api.rQshiftBytes  = rQshiftBytes;
+    api.rQslice       = rQslice;
+    api.rQwait        = rQwait;
 
-    api.flush        = flush;
-    api.send         = send;
-    api.send_string  = send_string;
+    api.flush         = flush;
+    api.send          = send;
+    api.send_string   = send_string;
 
-    api.on           = on;
-    api.init         = init;
-    api.open         = open;
-    api.close        = close;
-    api.testMode     = testMode;
+    api.on            = on;
+    api.init          = init;
+    api.open          = open;
+    api.close         = close;
+    api.testMode      = testMode;
 
     return api;
 }


### PR DESCRIPTION
Chinese characters have 3 bytes each after decoded by base64, and we need
combine 3 bytes into 1 2-byte unicode for String.fromCharCode(number); to
decode the character correctly.

Signed-off-by: Hongliang Wang <hlwang@linux.vnet.ibm.com>