### PR TITLE
Let mouse active even if there is touch

### DIFF
--- a/include/input.js
+++ b/include/input.js
@@ -355,14 +355,14 @@ that.grab = function() {
         Util.addEvent(window, 'touchend', onMouseUp);
         Util.addEvent(c, 'touchend', onMouseUp);
         Util.addEvent(c, 'touchmove', onMouseMove);
-    } else {
+    } //else {
         Util.addEvent(c, 'mousedown', onMouseDown);
         Util.addEvent(window, 'mouseup', onMouseUp);
         Util.addEvent(c, 'mouseup', onMouseUp);
         Util.addEvent(c, 'mousemove', onMouseMove);
         Util.addEvent(c, (Util.Engine.gecko) ? 'DOMMouseScroll' : 'mousewheel',
                 onMouseWheel);
-    }
+    //}
 
     /* Work around right and middle click browser behaviors */
     Util.addEvent(document, 'click', onMouseDisable);
@@ -380,14 +380,14 @@ that.ungrab = function() {
         Util.removeEvent(window, 'touchend', onMouseUp);
         Util.removeEvent(c, 'touchend', onMouseUp);
         Util.removeEvent(c, 'touchmove', onMouseMove);
-    } else {
+    } //else {
         Util.removeEvent(c, 'mousedown', onMouseDown);
         Util.removeEvent(window, 'mouseup', onMouseUp);
         Util.removeEvent(c, 'mouseup', onMouseUp);
         Util.removeEvent(c, 'mousemove', onMouseMove);
         Util.removeEvent(c, (Util.Engine.gecko) ? 'DOMMouseScroll' : 'mousewheel',
                 onMouseWheel);
-    }
+    //}
 
     /* Work around right and middle click browser behaviors */
     Util.removeEvent(document, 'click', onMouseDisable);


### PR DESCRIPTION
I ran into the problem on my laptop: it is touch-enabled, but im working with 2 external monitors. So until now only chrome is able to receive touch-events. But if there are touch-events the normal mouse wouldn work at the same time. FIXED with this little commis.