### PR TITLE
encode_message method should be parameterised

### DIFF
--- a/include/websock.js
+++ b/include/websock.js
@@ -158,13 +158,13 @@ function rQwait(msg, num, goback) {
 // Private utility routines
 //
 
-function encode_message() {
+function encode_message(sendQueue) {
     if (mode === 'binary') {
         // Put in a binary arraybuffer
-        return (new Uint8Array(sQ)).buffer;
+        return (new Uint8Array(sendQueue)).buffer;
     } else {
         // base64 encode
-        return Base64.encode(sQ);
+        return Base64.encode(sendQueue);
     }
 }
 


### PR DESCRIPTION
Since encode_message is using data in send queue, we either don't send the data (e.g. websocket.send(encode_message());)
or better to have a parameter.