### PR TITLE
Add common Linux key combination methods to rfb

### DIFF
--- a/include/rfb.js
+++ b/include/rfb.js
@@ -261,6 +261,46 @@ var RFB;
             this._sock.send(arr);
         },
 
+        sendCtrlAltBackspace: function () {
+            if (this._rfb_state !== 'normal' || this._view_only) { return false; }
+            Util.Info("Sending Ctrl-Alt-Backspace");
+
+            var arr = [];
+            arr = arr.concat(RFB.messages.keyEvent(0xFFE3, 1)); // Control
+            arr = arr.concat(RFB.messages.keyEvent(0xFFE9, 1)); // Alt
+            arr = arr.concat(RFB.messages.keyEvent(0xFF08, 1)); // Backspace
+            arr = arr.concat(RFB.messages.keyEvent(0xFF08, 0)); // Backspace
+            arr = arr.concat(RFB.messages.keyEvent(0xFFE9, 0)); // Alt
+            arr = arr.concat(RFB.messages.keyEvent(0xFFE3, 0)); // Control
+            this._sock.send(arr);
+        },
+
+        sendCtrlAltF: function (number) {
+            if (this._rfb_state !== 'normal' || this._view_only) { return false; }
+            Util.Info("Sending Ctrl-Alt-F" + number);
+
+            var arr = [];
+            arr = arr.concat(RFB.messages.keyEvent(0xFFE3, 1)); // Control
+            arr = arr.concat(RFB.messages.keyEvent(0xFFE9, 1)); // Alt
+            arr = arr.concat(RFB.messages.keyEvent(0xFFBD + number, 1)); // Fx
+            arr = arr.concat(RFB.messages.keyEvent(0xFFBD + number, 0)); // Fx
+            arr = arr.concat(RFB.messages.keyEvent(0xFFE9, 0)); // Alt
+            arr = arr.concat(RFB.messages.keyEvent(0xFFE3, 0)); // Control
+            this._sock.send(arr);
+        },
+
+        sendAltF: function (number) {
+            if (this._rfb_state !== 'normal' || this._view_only) { return false; }
+            Util.Info("Sending Alt-F" + number);
+
+            var arr = [];
+            arr = arr.concat(RFB.messages.keyEvent(0xFFE9, 1)); // Alt
+            arr = arr.concat(RFB.messages.keyEvent(0xFFBD + number, 1)); // Fx
+            arr = arr.concat(RFB.messages.keyEvent(0xFFBD + number, 0)); // Fx
+            arr = arr.concat(RFB.messages.keyEvent(0xFFE9, 0)); // Alt
+            this._sock.send(arr);
+        },
+
         xvpOp: function (ver, op) {
             if (this._rfb_xvp_ver < ver) { return false; }
             Util.Info("Sending XVP operation " + op + " (version " + ver + ")");


### PR DESCRIPTION
Add methods to send common Linux key combinations to VNC like ctrl+alt+Fx, alt+Fx and ctrl+alt+backspace.

I am not sure if this pr is worth merging into master but I had to create the methods for a project of mine and maybe someone else is interested in it.
It makes adding Linux key combination buttons to a noVNC page very easy.

For my project I have added them as overlay to a separate file so it is no problem to update noVNC automatically.