### PR TITLE
slip in PATH for 'npm test' as not everyone has karma

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "test": "tests"
   },
   "scripts": {
-    "test": "karma start karma.conf.js"
+    "test": "PATH=$PATH:node_modules/karma/bin karma start karma.conf.js"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
So people can follow the 'unit tests' instructions, we need
to make sure PATH includes the karma bin directory otherwise
we see the following:
```
aclouter@stevemcqueen:/usr/src/aten-ikvm/noVNC$ npm test

> noVNC@0.5.0 test /usr/src/aten-ikvm/noVNC
> karma start karma.conf.js

sh: 1: karma: not found
npm ERR! Test failed.  See above for more details.
npm ERR! not ok code 0
```