### PR TITLE
Unregister event listeners from websock.

### DIFF
--- a/include/rfb.js
+++ b/include/rfb.js
@@ -197,6 +197,7 @@ var RFB;
             } else {
                 this._fail("Server disconnected" + msg);
             }
+            this._sock.off('close');
         }.bind(this));
         this._sock.on('error', function (e) {
             Util.Warn("WebSocket on-error event");
@@ -239,6 +240,9 @@ var RFB;
 
         disconnect: function () {
             this._updateState('disconnect', 'Disconnecting');
+            this._sock.off('error');
+            this._sock.off('message');
+            this._sock.off('open');
         },
 
         sendPassword: function (passwd) {

--- a/include/websock.js
+++ b/include/websock.js
@@ -200,6 +200,10 @@ function Websock() {
         },
 
         // Event Handlers
+        off: function (evt) {
+            this._eventHandlers[evt] = function () {};
+        },
+
         on: function (evt, handler) {
             this._eventHandlers[evt] = handler;
         },

--- a/tests/test.rfb.js
+++ b/tests/test.rfb.js
@@ -62,6 +62,24 @@ describe('Remote Frame Buffer Protocol Client', function() {
                 expect(client._updateState).to.have.been.calledOnce;
                 expect(client._updateState).to.have.been.calledWith('disconnect');
             });
+
+            it('should unregister error event handler', function () {
+                sinon.spy(client._sock, 'off');
+                client.disconnect();
+                expect(client._sock.off).to.have.been.calledWith('error');
+            });
+
+            it('should unregister message event handler', function () {
+                sinon.spy(client._sock, 'off');
+                client.disconnect();
+                expect(client._sock.off).to.have.been.calledWith('message');
+            });
+
+            it('should unregister open event handler', function () {
+                sinon.spy(client._sock, 'off');
+                client.disconnect();
+                expect(client._sock.off).to.have.been.calledWith('open');
+            });
         });
 
         describe('#sendPassword', function () {
@@ -1708,6 +1726,14 @@ describe('Remote Frame Buffer Protocol Client', function() {
                 client._rfb_state = 'normal';
                 client._sock._websocket.close();
                 expect(client._rfb_state).to.equal('failed');
+            });
+
+            it('should unregister close event handler', function () {
+                sinon.spy(client._sock, 'off');
+                client.connect('host', 8675);
+                client._rfb_state = 'disconnect';
+                client._sock._websocket.close();
+                expect(client._sock.off).to.have.been.calledWith('close');
             });
 
             // error events do nothing


### PR DESCRIPTION
Prevents possible memory and event notification leaks when tearing down
connection and reestablishing a new one.