### PR TITLE
Replace custom getPosition algorithms with getBoundingClientRect.

### DIFF
--- a/include/util.js
+++ b/include/util.js
@@ -433,72 +433,11 @@ Util.load_scripts = function (files) {
 };
 
 
-// Get DOM element position on page
-//  This solution is based based on http://www.greywyvern.com/?post=331
-//  Thanks to Brian Huisman AKA GreyWyvern!
-Util.getPosition = (function () {
+Util.getPosition = function(obj) {
     "use strict";
-    function getStyle(obj, styleProp) {
-        var y;
-        if (obj.currentStyle) {
-            y = obj.currentStyle[styleProp];
-        } else if (window.getComputedStyle)
-            y = window.getComputedStyle(obj, null)[styleProp];
-        return y;
-    }
-
-    function scrollDist() {
-        var myScrollTop = 0, myScrollLeft = 0;
-        var html = document.getElementsByTagName('html')[0];
-
-        // get the scrollTop part
-        if (html.scrollTop && document.documentElement.scrollTop) {
-            myScrollTop = html.scrollTop;
-        } else if (html.scrollTop || document.documentElement.scrollTop) {
-            myScrollTop = html.scrollTop + document.documentElement.scrollTop;
-        } else if (document.body.scrollTop) {
-            myScrollTop = document.body.scrollTop;
-        } else {
-            myScrollTop = 0;
-        }
-
-        // get the scrollLeft part
-        if (html.scrollLeft && document.documentElement.scrollLeft) {
-            myScrollLeft = html.scrollLeft;
-        } else if (html.scrollLeft || document.documentElement.scrollLeft) {
-            myScrollLeft = html.scrollLeft + document.documentElement.scrollLeft;
-        } else if (document.body.scrollLeft) {
-            myScrollLeft = document.body.scrollLeft;
-        } else {
-            myScrollLeft = 0;
-        }
-
-        return [myScrollLeft, myScrollTop];
-    }
-
-    return function (obj) {
-        var curleft = 0, curtop = 0, scr = obj, fixed = false;
-        while ((scr = scr.parentNode) && scr != document.body) {
-            curleft -= scr.scrollLeft || 0;
-            curtop -= scr.scrollTop || 0;
-            if (getStyle(scr, "position") == "fixed") {
-                fixed = true;
-            }
-        }
-        if (fixed && !window.opera) {
-            var scrDist = scrollDist();
-            curleft += scrDist[0];
-            curtop += scrDist[1];
-        }
-
-        do {
-            curleft += obj.offsetLeft;
-            curtop += obj.offsetTop;
-        } while ((obj = obj.offsetParent));
-
-        return {'x': curleft, 'y': curtop};
-    };
-})();
+    var objPosition = obj.getBoundingClientRect();
+    return {'x': objPosition.left, 'y': objPosition.top};
+};
 
 
 // Get mouse event position in DOM element


### PR DESCRIPTION
The [`getBoundingClientRect()`](https://developer.mozilla.org/en-US/docs/Web/API/Element.getBoundingClientRect) call is native JavaScript and supported since Chrome 1, Firefox 3, Safari 4, IE4 (excluding width and height, which are not used here). It works more consistently than the existing implementation, especially when working with position static and fixed element hierarchies.

All tests still pass (although there are no tests covering this function). We did manually test in our own application with these changes, as well as in the packaged `vnc.html`.