### PR TITLE
Update tests/input.html to include keysym.js instead of keysymdef.js

### DIFF
--- a/tests/input.html
+++ b/tests/input.html
@@ -26,7 +26,7 @@
     <script src="../include/util.js"></script>
     <script src="../include/webutil.js"></script> 
     <script src="../include/base64.js"></script>
-    <script src="../include/keysymdef.js"></script> 
+    <script src="../include/keysym.js"></script>
     <script src="../include/keyboard.js"></script> 
     <script src="../include/input.js"></script> 
     <script src="../include/display.js"></script>


### PR DESCRIPTION
As pointed out [here](https://github.com/kanaka/noVNC/issues/21#issuecomment-72259534), the input.html test page had broken after the recent commits moving from keysymdef.js to keysym.js.

The problem simply seems to be that the page includes the wrong file.