### PR TITLE
keysym.js needs inclusion in debian's install list

### DIFF
--- a/debian/novnc.install
+++ b/debian/novnc.install
@@ -14,6 +14,7 @@ include/base64.js   /usr/share/novnc/include
 include/des.js   /usr/share/novnc/include
 include/display.js   /usr/share/novnc/include
 include/keysymdef.js   /usr/share/novnc/include
+include/keysym.js   /usr/share/novnc/include
 include/keyboard.js   /usr/share/novnc/include
 include/input.js   /usr/share/novnc/include
 include/logo.js   /usr/share/novnc/include


### PR DESCRIPTION
It's used but not being packaged.  Let's fix that!