### PR TITLE
Make Util.getPosition be relative to page

### DIFF
--- a/include/util.js
+++ b/include/util.js
@@ -436,7 +436,7 @@ Util.load_scripts = function (files) {
 Util.getPosition = function(obj) {
     "use strict";
     var objPosition = obj.getBoundingClientRect();
-    return {'x': objPosition.left, 'y': objPosition.top};
+    return {'x': objPosition.left + window.pageXOffset, 'y': objPosition.top + window.pageYOffset};
 };
 
 


### PR DESCRIPTION
Commit 5108c4635c847de9be0edadf572f7426f351b66a caused a regression
in the case where scrolling is used -- getPosition return position
relative to the viewport, while getEventPosition expected a position
relative to the page.

As per
https://developer.mozilla.org/en-US/docs/Web/API/Element/getBoundingClientRect,
the fix for this is simply to add the `pageXOffset` and `pageYOffset` to
the output of `getBoundingClientRect()`.

Fixes #459.