### PR TITLE
Fix resize in Firefox on Android

### DIFF
--- a/include/base.css
+++ b/include/base.css
@@ -112,13 +112,7 @@ html {
 
 /* Do not set width/height for VNC_screen or VNC_canvas or incorrect
  * scaling will occur. Canvas resizes to remote VNC settings */
-#noVNC_screen_pad {
-  margin: 0px;
-  padding: 0px;
-  height: 36px;
-}
 #noVNC_screen {
-  text-align: center;
   display: table;
   width:100%;
   height:100%;
@@ -127,13 +121,25 @@ html {
   /*border-top-left-radius: 800px 600px;*/
 }
 
-#noVNC_container, #noVNC_canvas {
+#noVNC_container {
+  display: none;
+  position: absolute;
   margin: 0px;
   padding: 0px;
+  bottom: 0px;
+  top: 36px; /* the height of the control bar */
+  left: 0px;
+  right: 0px;
+  width: auto;
+  height: auto;
 }
 
 #noVNC_canvas {
-  left: 0px;
+  position: absolute;
+  left: 0;
+  right: 0;
+  margin-left: auto;
+  margin-right: auto;
 }
 
 #VNC_clipboard_clear_button {

--- a/tests/test.display.js
+++ b/tests/test.display.js
@@ -134,6 +134,40 @@ describe('Display/Canvas Helper', function () {
         });
     });
 
+    describe('clipping', function () {
+        var display;
+        beforeEach(function () {
+            display = new Display({ target: document.createElement('canvas'), prefer_js: false, viewport: true });
+            display.resize(4, 3);
+        });
+
+        it('should report true when no max-size and framebuffer > viewport', function () {
+            display.viewportChangeSize(2,2);
+            var clipping = display.clippingDisplay();
+            expect(clipping).to.be.true;
+        });
+
+        it('should report false when no max-size and framebuffer = viewport', function () {
+            var clipping = display.clippingDisplay();
+            expect(clipping).to.be.false;
+        });
+
+        it('should report true when viewport > max-size and framebuffer > viewport', function () {
+            display.viewportChangeSize(2,2);
+            display.set_maxWidth(1);
+            display.set_maxHeight(2);
+            var clipping = display.clippingDisplay();
+            expect(clipping).to.be.true;
+        });
+
+        it('should report true when viewport > max-size and framebuffer = viewport', function () {
+            display.set_maxWidth(1);
+            display.set_maxHeight(2);
+            var clipping = display.clippingDisplay();
+            expect(clipping).to.be.true;
+        });
+    });
+
     describe('resizing', function () {
         var display;
         beforeEach(function () {

--- a/tests/test.rfb.js
+++ b/tests/test.rfb.js
@@ -1584,7 +1584,7 @@ describe('Remote Frame Buffer Protocol Client', function() {
                     });
 
                     it('should not handle a failed request', function () {
-                        var reason_for_change = 0; // non-incremental
+                        var reason_for_change = 1; // requested by this client
                         var status_code       = 1; // Resize is administratively prohibited
 
                         send_fbu_msg([{ x: reason_for_change, y: status_code,

--- a/vnc.html
+++ b/vnc.html
@@ -203,13 +203,11 @@
 
 
     <div id="noVNC_screen">
-        <div id="noVNC_screen_pad"></div>
-
         <h1 id="noVNC_logo"><span>no</span><br />VNC</h1>
 
         <!-- HTML5 Canvas -->
         <div id="noVNC_container">
-            <canvas id="noVNC_canvas" width="640px" height="20px">
+            <canvas id="noVNC_canvas" width="0" height="0">
                         Canvas not supported.
             </canvas>
         </div>


### PR DESCRIPTION
This fixes issues #446 and #463 by using a different approach of getting the full size of the canvas. Instead of using window.innerWidth and window.innerHeight this would resize the canvas to fit the noVNC_container which covers the entire page.

Edit: This also fixes issue #465