### PR TITLE
Throw exceptions from RFB constructor

### DIFF
--- a/include/display.js
+++ b/include/display.js
@@ -86,29 +86,9 @@ var Display;
         }
 
         // Determine browser support for setting the cursor via data URI scheme
-        var curDat = [];
-        for (var i = 0; i < 8 * 8 * 4; i++) {
-            curDat.push(255);
-        }
-        try {
-            var curSave = this._target.style.cursor;
-            Display.changeCursor(this._target, curDat, curDat, 2, 2, 8, 8);
-            if (this._target.style.cursor) {
-                if (this._cursor_uri === null || this._cursor_uri === undefined) {
-                    this._cursor_uri = true;
-                }
-                Util.Info("Data URI scheme cursor supported");
-                this._target.style.cursor = curSave;
-            } else {
-                if (this._cursor_uri === null || this._cursor_uri === undefined) {
-                    this._cursor_uri = false;
-                }
-                Util.Warn("Data URI scheme cursor not supported");
-                this._target.style.cursor = "none";
-            }
-        } catch (exc) {
-            Util.Error("Data URI scheme cursor test exception: " + exc);
-            this._cursor_uri = false;
+        if (this._cursor_uri || this._cursor_uri === null ||
+                this._cursor_uri === undefined) {
+            this._cursor_uri = Util.browserSupportsCursorURIs(this._target);
         }
 
         Util.Debug("<< Display.constructor");

--- a/include/ui.js
+++ b/include/ui.js
@@ -159,13 +159,19 @@ var UI;
         },
 
         initRFB: function () {
-            UI.rfb = new RFB({'target': $D('noVNC_canvas'),
-                              'onUpdateState': UI.updateState,
-                              'onXvpInit': UI.updateXvpVisualState,
-                              'onClipboard': UI.clipReceive,
-                              'onFBUComplete': UI.FBUComplete,
-                              'onFBResize': UI.updateViewDragButton,
-                              'onDesktopName': UI.updateDocumentTitle});
+            try {
+                UI.rfb = new RFB({'target': $D('noVNC_canvas'),
+                                  'onUpdateState': UI.updateState,
+                                  'onXvpInit': UI.updateXvpVisualState,
+                                  'onClipboard': UI.clipReceive,
+                                  'onFBUComplete': UI.FBUComplete,
+                                  'onFBResize': UI.updateViewDragButton,
+                                  'onDesktopName': UI.updateDocumentTitle});
+                return true;
+            } catch (exc) {
+                UI.updateState(null, 'fatal', null, 'Unable to create RFB client -- ' + exc);
+                return false;
+            }
         },
 
         addMouseHandlers: function() {
@@ -772,7 +778,7 @@ var UI;
                 throw new Error("Must set host and port");
             }
 
-            UI.initRFB();
+            if (!UI.initRFB()) return;
 
             UI.rfb.set_encrypt(UI.getSetting('encrypt'));
             UI.rfb.set_true_color(UI.getSetting('true_color'));

--- a/include/util.js
+++ b/include/util.js
@@ -508,6 +508,29 @@ Util.stopEvent = function (e) {
     else                   { e.returnValue = false; }
 };
 
+Util._cursor_uris_supported = null;
+
+Util.browserSupportsCursorURIs = function () {
+    if (Util._cursor_uris_supported === null) {
+        try {
+            var target = document.createElement('canvas');
+            target.style.cursor = 'url("data:image/x-icon;base64,AAACAAEACAgAAAIAAgA4AQAAFgAAACgAAAAIAAAAEAAAAAEAIAAAAAAAEAAAAAAAAAAAAAAAAAAAAAAAAAD/////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////AAAAAAAAAAAAAAAAAAAAAA==") 2 2, default';
+
+            if (target.style.cursor) {
+                Util.Info("Data URI scheme cursor supported");
+                Util._cursor_uris_supported = true;
+            } else {
+                Util.Warn("Data URI scheme cursor not supported");
+                Util._cursor_uris_supported = false;
+            }
+        } catch (exc) {
+            Util.Error("Data URI scheme cursor test exception: " + exc);
+            Util._cursor_uris_supported = false;
+        }
+    }
+
+    return Util._cursor_uris_supported;
+};
 
 // Set browser engine versions. Based on mootools.
 Util.Features = {xpath: !!(document.evaluate), air: !!(window.runtime), query: !!(document.querySelector)};

--- a/tests/test.display.js
+++ b/tests/test.display.js
@@ -28,35 +28,29 @@ describe('Display/Canvas Helper', function () {
 
     describe('checking for cursor uri support', function () {
         beforeEach(function () {
-            this._old_change_cursor = Display.changeCursor;
+            this._old_browser_supports_cursor_uris = Util.browserSupportsCursorURIs;
         });
 
         it('should disable cursor URIs if there is no support', function () {
-            Display.changeCursor = function(target) {
-                target.style.cursor = undefined;
-            };
+            Util.browserSupportsCursorURIs = function () { return false; };
             var display = new Display({ target: document.createElement('canvas'), prefer_js: true, viewport: false });
             expect(display._cursor_uri).to.be.false;
         });
 
         it('should enable cursor URIs if there is support', function () {
-            Display.changeCursor = function(target) {
-                target.style.cursor = 'pointer';
-            };
+            Util.browserSupportsCursorURIs = function () { return true; };
             var display = new Display({ target: document.createElement('canvas'), prefer_js: true, viewport: false });
             expect(display._cursor_uri).to.be.true;
         });
 
         it('respect the cursor_uri option if there is support', function () {
-            Display.changeCursor = function(target) {
-                target.style.cursor = 'pointer';
-            };
+            Util.browserSupportsCursorURIs = function () { return false; };
             var display = new Display({ target: document.createElement('canvas'), prefer_js: true, viewport: false, cursor_uri: false });
             expect(display._cursor_uri).to.be.false;
         });
 
         afterEach(function () {
-            Display.changeCursor = this._old_change_cursor;
+            Util.browserSupportsCursorURIs = this._old_browser_supports_cursor_uris;
         });
     });
 

--- a/vnc.html
+++ b/vnc.html
@@ -46,7 +46,7 @@
 </head>
 
 <body>
-    <div id="noVNC-control-bar">
+    <div id="noVNC-control-bar" class="noVNC_status_normal">
         <!--noVNC Mobile Device only Buttons-->
         <div class="noVNC-buttons-left">
             <input type="image" alt="viewport drag" src="images/drag.png"
@@ -87,7 +87,7 @@
             </div>
         </div>
 
-        <div id="noVNC_status">Loading</div>
+        <div id="noVNC_status"></div>
 
         <!--noVNC Buttons-->
         <div class="noVNC-buttons-right">

--- a/vnc_auto.html
+++ b/vnc_auto.html
@@ -216,18 +216,24 @@
                 return;
             }
 
-            rfb = new RFB({'target':       $D('noVNC_canvas'),
-                           'encrypt':      WebUtil.getQueryVar('encrypt',
-                                    (window.location.protocol === "https:")),
-                           'repeaterID':   WebUtil.getQueryVar('repeaterID', ''),
-                           'true_color':   WebUtil.getQueryVar('true_color', true),
-                           'local_cursor': WebUtil.getQueryVar('cursor', true),
-                           'shared':       WebUtil.getQueryVar('shared', true),
-                           'view_only':    WebUtil.getQueryVar('view_only', false),
-                           'onUpdateState':  updateState,
-                           'onXvpInit':    xvpInit,
-                           'onPasswordRequired':  passwordRequired,
-                           'onFBUComplete': FBUComplete});
+            try {
+                rfb = new RFB({'target':       $D('noVNC_canvas'),
+                               'encrypt':      WebUtil.getQueryVar('encrypt',
+                                        (window.location.protocol === "https:")),
+                               'repeaterID':   WebUtil.getQueryVar('repeaterID', ''),
+                               'true_color':   WebUtil.getQueryVar('true_color', true),
+                               'local_cursor': WebUtil.getQueryVar('cursor', true),
+                               'shared':       WebUtil.getQueryVar('shared', true),
+                               'view_only':    WebUtil.getQueryVar('view_only', false),
+                               'onUpdateState':  updateState,
+                               'onXvpInit':    xvpInit,
+                               'onPasswordRequired':  passwordRequired,
+                               'onFBUComplete': FBUComplete});
+            } catch (exc) {
+                UI.updateState(null, 'fatal', null, 'Unable to create RFB client -- ' + exc);
+                return; // don't continue trying to connect
+            }
+
             rfb.connect(host, port, password, path);
         };
         </script>


### PR DESCRIPTION
Throw error from constructor on Display error
    
Previously, if an error was thrown from the Display constructor in the RFB constructor, we would attempt to use `RFB#updateState`` to handle this.  However, `RFB#updateState` attempts to close the WebSocket connection, which doesn't exist at this point.
    
In the constructor, it's probably just better to raise an exception instead (making sure to clean up anything relevant), both for errors from the display constructor, and for errors due to WebSocket emulation.
    
Fixes #460
