### PR TITLE
Follow symbolic links in launch.sh

### DIFF
--- a/utils/launch.sh
+++ b/utils/launch.sh
@@ -22,7 +22,8 @@ usage() {
 }
 
 NAME="$(basename $0)"
-HERE="$(cd "$(dirname "$0")" && pwd)"
+REAL_NAME="$(readlink -f $0)"
+HERE="$(cd "$(dirname "$REAL_NAME")" && pwd)"
 PORT="6080"
 VNC_DEST="localhost:5900"
 CERT=""


### PR DESCRIPTION
Previously, in launch.sh, `$HERE` was the directory of `$0`.
However, if `$0` was actually a symlink, `$HERE` would be
wherever the symlink was, which could cause issues (for
example, the script wouldn't be able to local `$WEB` or
`$WEBSOCKIFY` properly).

Now, `$HERE` looks at whatever `$0` points at instead.

Closes #447.