### PR TITLE
Make noVNC compatible with Content Security Policies

### DIFF
--- a/include/base.css
+++ b/include/base.css
@@ -238,6 +238,7 @@ html {
   position: relative;
   left: -40px;
   z-index: -1;
+  ime-mode: disabled;
 }
 
 /*

--- a/include/ui.js
+++ b/include/ui.js
@@ -185,6 +185,7 @@ var UI;
 
             $D("keyboardinput").oninput = UI.keyInput;
             $D("keyboardinput").onblur = UI.keyInputBlur;
+            $D("keyboardinput").onsubmit = function () { return false; };
 
             $D("showExtraKeysButton").onclick = UI.showExtraKeys;
             $D("toggleCtrlButton").onclick = UI.toggleCtrl;

--- a/vnc.html
+++ b/vnc.html
@@ -70,8 +70,7 @@
                      style for example -->
                 <textarea id="keyboardinput" autocapitalize="off"
                     autocorrect="off" autocomplete="off" spellcheck="false"
-                    mozactionhint="Enter" onsubmit="return false;"
-                    style="ime-mode: disabled;"></textarea>
+                    mozactionhint="Enter"></textarea>
                 <div id="noVNC_extra_keys">
                     <input type="image" alt="Extra keys" src="images/showextrakeys.png"
                         id="showExtraKeysButton" class="noVNC_status_button">


### PR DESCRIPTION
This pull request simply moves the style and onsubmit declarations from #keyboardinput in vnc.html to base.css and ui.js, making it possible to use noVNC on mobile devices with an active Content Security Policy after these small changes.

An example policy header working with noVNC (note ws://127.0.0.1:8080 needs to be replaced with the scheme, host & port noVNC should connect to):

```
default-src 'none'; font-src 'self'; script-src 'self'; img-src 'self' data:; style-src 'self'; connect-src 'self' ws://127.0.0.1:8080;
```

I admit this is not terribly useful if noVNC should connect to different clients, but for integration into specific applications this may improve security, and the needed changes are not too big.
