### PR TITLE
Fix occasional error with sending while readyState !== 1

### DIFF
--- a/include/websock.js
+++ b/include/websock.js
@@ -175,7 +175,7 @@ function Websock() {
             }
 
             if (this._websocket.bufferedAmount < this.maxBufferedAmount) {
-                if (this._sQ.length > 0) {
+                if (this._sQ.length > 0 && this._websocket.readyState === 1) {
                     this._websocket.send(this._encode_message());
                     this._sQ = [];
                 }

--- a/include/websock.js
+++ b/include/websock.js
@@ -175,7 +175,7 @@ function Websock() {
             }
 
             if (this._websocket.bufferedAmount < this.maxBufferedAmount) {
-                if (this._sQ.length > 0 && this._websocket.readyState === 1) {
+                if (this._sQ.length > 0 && this._websocket.readyState === WebSocket.OPEN) {
                     this._websocket.send(this._encode_message());
                     this._sQ = [];
                 }

--- a/tests/test.websock.js
+++ b/tests/test.websock.js
@@ -180,6 +180,7 @@ describe('Websock', function() {
             it('should actually send on the websocket if the websocket does not have too much buffered', function () {
                 sock.maxBufferedAmount = 10;
                 sock._websocket.bufferedAmount = 8;
+                sock._websocket.readyState = 1;
                 sock._sQ = [1, 2, 3];
                 var encoded = sock._encode_message();
 


### PR DESCRIPTION
Under certain conditions, noVNC would attempt to flush the web socket
while it was disconnected, before the disconnected state was picked up.
This casues noVNC to crash ungracefully and the parent window is not
notified - leading to no chance at recovery without a page refresh.