### PR TITLE
Fix buffer over-reads in handle_tight

### DIFF
--- a/include/rfb.js
+++ b/include/rfb.js
@@ -1782,8 +1782,8 @@ var RFB;
                 return dest;
             }.bind(this);
 
-            var rQ = this._sock.get_rQ();
             var rQi = this._sock.get_rQi();
+            var rQ = this._sock.rQwhole();
             var cmode, data;
             var cl_header, cl_data;
 

--- a/include/websock.js
+++ b/include/websock.js
@@ -154,6 +154,10 @@ function Websock() {
             this._rQi += len;
         },
 
+        rQwhole: function () {
+            return new Uint8Array(this._rQ.buffer, 0, this._rQlen);
+        },
+
         rQslice: function (start, end) {
             if (end) {
                 return new Uint8Array(this._rQ.buffer, this._rQi + start, end - start);


### PR DESCRIPTION
For performance reasons, the `handle_tight` function skips the
use of the receive queue API and uses the raw receive queue directly.
Because of the way that typed array receive queue gets reused, this
introduced the potential for buffer over-reads.

To address this, a new function, `rQwhole`, was introduced.
`rQwhole` simply returns a new view into the receive queue that
starts at 0 and ends at the current recorded end of the queue.

`handle_tight` now makes use of this function.

Fixes #522