### PR TITLE
Make sure Pako always has enough room

### DIFF
--- a/docs/notes
+++ b/docs/notes
@@ -2,4 +2,4 @@ Rebuilding inflator.js
 
 - Download pako from npm
 - Install browserify using npm
-- browserify utils/inflator.partial.js -o include/inflator.js
+- browserify utils/inflator.partial.js -o include/inflator.js -s inflator

--- a/include/rfb.js
+++ b/include/rfb.js
@@ -1688,16 +1688,17 @@ var RFB;
 
             var resetStreams = 0;
             var streamId = -1;
-            var decompress = function (data) {
+            var decompress = function (data, expected) {
                 for (var i = 0; i < 4; i++) {
                     if ((resetStreams >> i) & 1) {
                         this._FBU.zlibs[i].reset();
+                        console.debug('RESET!');
                         Util.Info("Reset zlib stream " + i);
                     }
                 }
 
                 //var uncompressed = this._FBU.zlibs[streamId].uncompress(data, 0);
-                var uncompressed = this._FBU.zlibs[streamId].inflate(data, true);
+                var uncompressed = this._FBU.zlibs[streamId].inflate(data, true, expected);
                 /*if (uncompressed.status !== 0) {
                     Util.Error("Invalid data in zlib stream");
                 }*/
@@ -1830,7 +1831,7 @@ var RFB;
                 if (raw) {
                     data = this._sock.rQshiftBytes(cl_data);
                 } else {
-                    data = decompress(this._sock.rQshiftBytes(cl_data));
+                    data = decompress(this._sock.rQshiftBytes(cl_data), rowSize * this._FBU.height);
                 }
 
                 // Convert indexed (palette based) image data to RGB
@@ -1879,7 +1880,7 @@ var RFB;
                 if (raw) {
                     data = this._sock.rQshiftBytes(cl_data);
                 } else {
-                    data = decompress(this._sock.rQshiftBytes(cl_data));
+                    data = decompress(this._sock.rQshiftBytes(cl_data), uncompressedSize);
                 }
 
                 this._display.blitRgbImage(this._FBU.x, this._FBU.y, this._FBU.width, this._FBU.height, data, 0, false);

--- a/utils/inflator.partial.js
+++ b/utils/inflator.partial.js
@@ -1,5 +1,5 @@
-var zlib = require('./lib/zlib/inflate.js');
-var ZStream = require('./lib/zlib/zstream.js');
+var zlib = require('../node_modules/pako/lib/zlib/inflate.js');
+var ZStream = require('../node_modules/pako/lib/zlib/zstream.js');
 
 var Inflate = function () {
     this.strm = new ZStream();
@@ -11,11 +11,19 @@ var Inflate = function () {
 };
 
 Inflate.prototype = {
-    inflate: function (data, flush) {
+    inflate: function (data, flush, expected) {
         this.strm.input = data;
         this.strm.avail_in = this.strm.input.length;
         this.strm.next_in = 0;
         this.strm.next_out = 0;
+
+        // resize our output buffer if it's too small
+        // (we could just use multiple chunks, but that would cause an extra
+        // allocation each time to flatten the chunks)
+        if (expected > this.chunkSize) {
+            this.chunkSize = expected;
+            this.strm.output = new Uint8Array(this.chunkSize);
+        }
 
         this.strm.avail_out = this.chunkSize;
 


### PR DESCRIPTION
Previously, we used a fixed chunkSize of 100KiB for Pako's output
buffer.  Using a hardcoded size caused issues, since Pako would assume
we wanted to use multiple chunks, and we didn't deal with this.  Now,
`Inflator#inflate()` takes a new `expected` argument, which indicates
the expected output size.  If this is bigger than the current chunkSize,
Inflator allocates a new output buffer that's big enough to hold the
output.

Fixes #531