### PR TITLE
Fixes VNC standard auth using onPasswordRequired callback

### DIFF
--- a/include/rfb.js
+++ b/include/rfb.js
@@ -739,6 +739,7 @@ var RFB;
                 // an RFB state change and a UI interface issue
                 this._updateState('password', "Password Required");
                 this._onPasswordRequired(this);
+                return false;
             }
 
             if (this._sock.rQwait("auth challenge", 16)) { return false; }


### PR DESCRIPTION
Should return and wait for the sendPassword-call to trigger the actual authentication. Fixes #542.