### PR TITLE
Add hash fragment as an optional method to supply config variables.

### DIFF
--- a/include/ui.js
+++ b/include/ui.js
@@ -97,7 +97,7 @@ var UI;
             UI.initSetting('path', 'websockify');
             UI.initSetting('repeaterID', '');
 
-            var autoconnect = WebUtil.getQueryVar('autoconnect', false);
+            var autoconnect = WebUtil.getConfigVar('autoconnect', false);
             if (autoconnect === 'true' || autoconnect == '1') {
                 autoconnect = true;
                 UI.connect();
@@ -355,7 +355,7 @@ var UI;
         // Initial page load read/initialization of settings
         initSetting: function(name, defVal) {
             // Check Query string followed by cookie
-            var val = WebUtil.getQueryVar(name);
+            var val = WebUtil.getConfigVar(name);
             if (val === null) {
                 val = WebUtil.readSetting(name, defVal);
             }

--- a/include/webutil.js
+++ b/include/webutil.js
@@ -90,6 +90,29 @@ WebUtil.getQueryVar = function (name, defVal) {
     }
 };
 
+// Read a hash fragment variable
+WebUtil.getHashVar = function (name, defVal) {
+    "use strict";
+    var re = new RegExp('.*[&#]' + name + '=([^&]*)'),
+        match = document.location.hash.match(re);
+    if (typeof defVal === 'undefined') { defVal = null; }
+    if (match) {
+        return decodeURIComponent(match[1]);
+    } else {
+        return defVal;
+    }
+};
+
+// Read a variable from the fragment or the query string
+// Fragment takes precedence
+WebUtil.getConfigVar = function (name, defVal) {
+    "use strict";
+    var val = WebUtil.getHashVar(name);
+    if (val === null) {
+        val = WebUtil.getQueryVar(name, defVal);
+    }
+    return val;
+};
 
 /*
  * Cookie handling. Dervied from: http://www.quirksmode.org/js/cookies.html

--- a/vnc.html
+++ b/vnc.html
@@ -11,6 +11,8 @@
 
     Connect parameters are provided in query string:
         http://example.com/?host=HOST&port=PORT&encrypt=1&true_color=1
+    or the fragment:
+        http://example.com/#host=HOST&port=PORT&encrypt=1&true_color=1
     -->
     <title>noVNC</title>
 

--- a/vnc_auto.html
+++ b/vnc_auto.html
@@ -11,6 +11,8 @@
 
     Connect parameters are provided in query string:
         http://example.com/?host=HOST&port=PORT&encrypt=1&true_color=1
+    or the fragment:
+        http://example.com/#host=HOST&port=PORT&encrypt=1&true_color=1
     -->
     <title>noVNC</title>
 
@@ -84,7 +86,7 @@
 
 
         function UIresize() {
-            if (WebUtil.getQueryVar('resize', false)) {
+            if (WebUtil.getConfigVar('resize', false)) {
                 var innerW = window.innerWidth;
                 var innerH = window.innerHeight;
                 var controlbarH = $D('noVNC_status_bar').offsetHeight;
@@ -183,11 +185,11 @@
             $D('xvpRebootButton').onclick = xvpReboot;
             $D('xvpResetButton').onclick = xvpReset;
 
-            WebUtil.init_logging(WebUtil.getQueryVar('logging', 'warn'));
-            document.title = unescape(WebUtil.getQueryVar('title', 'noVNC'));
+            WebUtil.init_logging(WebUtil.getConfigVar('logging', 'warn'));
+            document.title = unescape(WebUtil.getConfigVar('title', 'noVNC'));
             // By default, use the host and port of server that served this file
-            host = WebUtil.getQueryVar('host', window.location.hostname);
-            port = WebUtil.getQueryVar('port', window.location.port);
+            host = WebUtil.getConfigVar('host', window.location.hostname);
+            port = WebUtil.getConfigVar('port', window.location.port);
 
             // if port == 80 (or 443) then it won't be present and should be
             // set manually
@@ -202,13 +204,13 @@
 
             // If a token variable is passed in, set the parameter in a cookie.
             // This is used by nova-novncproxy.
-            token = WebUtil.getQueryVar('token', null);
+            token = WebUtil.getConfigVar('token', null);
             if (token) {
                 WebUtil.createCookie('token', token, 1)
             }
 
-            password = WebUtil.getQueryVar('password', '');
-            path = WebUtil.getQueryVar('path', 'websockify');
+            password = WebUtil.getConfigVar('password', '');
+            path = WebUtil.getConfigVar('path', 'websockify');
 
             if ((!host) || (!port)) {
                 updateState(null, 'fatal', null, 'Must specify host and port in URL');
@@ -217,13 +219,13 @@
 
             try {
                 rfb = new RFB({'target':       $D('noVNC_canvas'),
-                               'encrypt':      WebUtil.getQueryVar('encrypt',
+                               'encrypt':      WebUtil.getConfigVar('encrypt',
                                         (window.location.protocol === "https:")),
-                               'repeaterID':   WebUtil.getQueryVar('repeaterID', ''),
-                               'true_color':   WebUtil.getQueryVar('true_color', true),
-                               'local_cursor': WebUtil.getQueryVar('cursor', true),
-                               'shared':       WebUtil.getQueryVar('shared', true),
-                               'view_only':    WebUtil.getQueryVar('view_only', false),
+                               'repeaterID':   WebUtil.getConfigVar('repeaterID', ''),
+                               'true_color':   WebUtil.getConfigVar('true_color', true),
+                               'local_cursor': WebUtil.getConfigVar('cursor', true),
+                               'shared':       WebUtil.getConfigVar('shared', true),
+                               'view_only':    WebUtil.getConfigVar('view_only', false),
                                'onUpdateState':  updateState,
                                'onXvpInit':    xvpInit,
                                'onPasswordRequired':  passwordRequired,


### PR DESCRIPTION
Any config variable like host, port, password, token may be
specified either in the query string (like now), or in the URL hash
fragment. In case a given variable is present in both, the value in the
fragment takes precedence. Supplying variables in the fragment avoids
leaking them to the web server hosting the noVNC viewer HTML.