### PR TITLE
Push image to the render queue when it is loaded

### DIFF
--- a/include/rfb.js
+++ b/include/rfb.js
@@ -1958,14 +1958,16 @@ var RFB;
                     // We have everything, render it
                     this._sock.rQskipBytes(1 + cl_header);  // shift off clt + compact length
                     var img = new Image();
-                    img.src = "data: image/" + cmode +
+                    img.onload = function (img, x, y) {
+                        this._display.renderQ_push({
+                            'type': 'img',
+                            'img': img,
+                            'x': x,
+                            'y': y
+                        });
+                    }.bind(this, img, this._FBU.x, this._FBU.y);
+                    img.src = "data:image/" + cmode +
                         RFB.extract_data_uri(this._sock.rQshiftBytes(cl_data));
-                    this._display.renderQ_push({
-                        'type': 'img',
-                        'img': img,
-                        'x': this._FBU.x,
-                        'y': this._FBU.y
-                    });
                     img = null;
                     break;
                 case "filter":


### PR DESCRIPTION
When running noVNC in Firefox or Safari, I noticed some glitches on the canvas from time to time. It turned out that the received image is drawn before it's loaded. Even though, `img.src` is a base64 string, it does not guarantee that the image is immediately available.

I added an `img.onload` callback which pushes the image to the queue instead of pushing it immediately.