### PR TITLE
fix negotiation fail when empty sub-auth types received

### DIFF
--- a/include/rfb.js
+++ b/include/rfb.js
@@ -795,6 +795,11 @@ var RFB;
             // second pass, do the sub-auth negotiation
             if (this._sock.rQwait("sub auth count", 4)) { return false; }
             var subAuthCount = this._sock.rQshift32();
+            if (subAuthCount === 0) {  // empty sub-auth list received means 'no auth' subtype selected
+                this._updateState('SecurityResult');
+                return true;
+            }
+
             if (this._sock.rQwait("sub auth capabilities", 16 * subAuthCount, 4)) { return false; }
 
             var clientSupportedTypes = {


### PR DESCRIPTION
When a TightVNC server configured to allow no-auth connection, it may sends (the recent TightVNC server actually sends) an empty 'sub-auth' capabilities list at tight security type sub-auth negotiation phase.  In this case noVNC viewer fails  on negotiation with ''Unsupported tiny auth scheme:" message.
Fix this to assume 'no-auth' authentication subtype selected when received an empty auth capabilities list.