### PR TITLE
Resize Receive Queue to Fit Incoming Messages

### DIFF
--- a/include/websock.js
+++ b/include/websock.js
@@ -67,6 +67,11 @@ function Websock() {
 (function () {
     "use strict";
 
+    // this has performance issues in some versions Chromium, and
+    // doesn't gain a tremendous amount of performance increase in Firefox
+    // at the moment.  It may be valuable to turn it on in the future.
+    var ENABLE_COPYWITHIN = false;
+
     var typedArrayToString = (function () {
         // This is only for PhantomJS, which doesn't like apply-ing
         // with Typed Arrays
@@ -364,8 +369,7 @@ function Websock() {
                             this._rQ = new Uint8Array(this._rQbufferSize);
                             this._rQ.set(new Uint8Array(old_rQbuffer, this._rQi));
                         } else {
-                            if (this._rQ.copyWithin) {
-                                // Firefox only, ATM
+                            if (ENABLE_COPYWITHIN) {
                                 this._rQ.copyWithin(0, this._rQi);
                             } else {
                                 this._rQ.set(new Uint8Array(this._rQ.buffer, this._rQi));

--- a/tests/test.websock.js
+++ b/tests/test.websock.js
@@ -404,6 +404,20 @@ describe('Websock', function() {
             expect(sock.get_rQi()).to.equal(0);
         });
 
+        it('should automatically resize the receive queue if the incoming message is too large', function () {
+            sock._rQ = new Uint8Array(20);
+            sock._rQlen = 0;
+            sock.set_rQi(0);
+            sock._rQbufferSize = 20;
+            sock._rQmax = 2;
+            var msg = { data: new Uint8Array(30).buffer };
+            sock._mode = 'binary';
+            sock._recv_message(msg);
+            expect(sock._rQlen).to.equal(30);
+            expect(sock.get_rQi()).to.equal(0);
+            expect(sock._rQ.length).to.equal(240);  // keep the invariant that rQbufferSize / 8 >= rQlen
+        });
+
         it('should call the error event handler on an exception', function () {
             sock._eventHandlers.error = sinon.spy();
             sock._eventHandlers.message = sinon.stub().throws();


### PR DESCRIPTION
This PR causes the receive queue to be resized in order to fit incoming messages.  There is a hard cap of a size of 40 MiB, so that we can't consume too much memory by accident.

Fixes #557 