### PR TITLE
Handle missing leading slash in elem.pathname

### DIFF
--- a/include/webutil.js
+++ b/include/webutil.js
@@ -282,5 +282,10 @@ WebUtil.injectParamIfMissing = function (path, param, value) {
         elem.search = "?" + query.join("&");
     }
 
-    return elem.pathname.slice(1) + elem.search + elem.hash;
+    // some browsers (e.g. IE11) may occasionally omit the leading slash
+    // in the elem.pathname string. Handle that case gracefully.
+    if (elem.pathname.charAt(0) == "/") {
+        return elem.pathname.slice(1) + elem.search + elem.hash;
+    } else {
+        return elem.pathname + elem.search + elem.hash;
 };


### PR DESCRIPTION
IE11 with compat mode turned off has been observed displaying this behavior.  This commit checks for and corrects this broken behavior.

Fixes #591