### PR TITLE
Added option for --ssl-only noVNC session

### DIFF
--- a/utils/launch.sh
+++ b/utils/launch.sh
@@ -5,7 +5,7 @@ usage() {
         echo "$*"
         echo
     fi
-    echo "Usage: ${NAME} [--listen PORT] [--vnc VNC_HOST:PORT] [--cert CERT]"
+    echo "Usage: ${NAME} [--listen PORT] [--vnc VNC_HOST:PORT] [--cert CERT] [--ssl-only]"
     echo
     echo "Starts the WebSockets proxy and a mini-webserver and "
     echo "provides a cut-and-paste URL to go to."
@@ -18,6 +18,8 @@ usage() {
     echo "                          Default: self.pem"
     echo "    --web WEB             Path to web files (e.g. vnc.html)"
     echo "                          Default: ./"
+    echo "    --ssl-only            Disable non-https connections."
+    echo "                                    "
     exit 2
 }
 
@@ -29,6 +31,7 @@ VNC_DEST="localhost:5900"
 CERT=""
 WEB=""
 proxy_pid=""
+SSLONLY=""
 
 die() {
     echo "$*"
@@ -55,6 +58,7 @@ while [ "$*" ]; do
     --vnc)     VNC_DEST="${OPTARG}"; shift        ;;
     --cert)    CERT="${OPTARG}"; shift            ;;
     --web)     WEB="${OPTARG}"; shift            ;;
+    --ssl-only) SSLONLY="--ssl-only"             ;;
     -h|--help) usage                              ;;
     -*) usage "Unknown chrooter option: ${param}" ;;
     *) break                                      ;;
@@ -134,7 +138,7 @@ fi
 
 echo "Starting webserver and WebSockets proxy on port ${PORT}"
 #${HERE}/websockify --web ${WEB} ${CERT:+--cert ${CERT}} ${PORT} ${VNC_DEST} &
-${WEBSOCKIFY} --web ${WEB} ${CERT:+--cert ${CERT}} ${PORT} ${VNC_DEST} &
+${WEBSOCKIFY} ${SSLONLY} --web ${WEB} ${CERT:+--cert ${CERT}} ${PORT} ${VNC_DEST} &
 proxy_pid="$!"
 sleep 1
 if ! ps -p ${proxy_pid} >/dev/null; then

--- a/utils/launch.sh
+++ b/utils/launch.sh
@@ -148,7 +148,12 @@ if ! ps -p ${proxy_pid} >/dev/null; then
 fi
 
 echo -e "\n\nNavigate to this URL:\n"
-echo -e "    http://$(hostname):${PORT}/vnc.html?host=$(hostname)&port=${PORT}\n"
+if [ "x$SSLONLY" == "x" ]; then
+    echo -e "    http://$(hostname):${PORT}/vnc.html?host=$(hostname)&port=${PORT}\n"
+else
+    echo -e "    https://$(hostname):${PORT}/vnc.html?host=$(hostname)&port=${PORT}\n"
+fi
+
 echo -e "Press Ctrl-C to exit\n\n"
 
 wait ${proxy_pid}


### PR DESCRIPTION
Added an option. `--ssl-only`, to the `launch.sh` script.  This option is passed through to the underlying `websockify` executable.  The end result is a `noVNC` session which rejects `http` connections but will accept `https` connections, assuming the other preconditions for `https` have been met.

I apologize for the lack of a unit test to accompany this change, but I'm not a web developer and wasn't really sure how to go about adding one!  