### PR TITLE
Enabling mouse use in chrome along touch.

### DIFF
--- a/include/input.js
+++ b/include/input.js
@@ -332,19 +332,12 @@ var Keyboard, Mouse;
         grab: function () {
             var c = this._target;
 
-            if ('ontouchstart' in document.documentElement) {
-                Util.addEvent(c, 'touchstart', this._eventHandlers.mousedown);
-                Util.addEvent(window, 'touchend', this._eventHandlers.mouseup);
-                Util.addEvent(c, 'touchend', this._eventHandlers.mouseup);
-                Util.addEvent(c, 'touchmove', this._eventHandlers.mousemove);
-            } else {
-                Util.addEvent(c, 'mousedown', this._eventHandlers.mousedown);
-                Util.addEvent(window, 'mouseup', this._eventHandlers.mouseup);
-                Util.addEvent(c, 'mouseup', this._eventHandlers.mouseup);
-                Util.addEvent(c, 'mousemove', this._eventHandlers.mousemove);
-                Util.addEvent(c, (Util.Engine.gecko) ? 'DOMMouseScroll' : 'mousewheel',
-                              this._eventHandlers.mousewheel);
-            }
+            Util.addEvent(c, 'mousedown', this._eventHandlers.mousedown);
+            Util.addEvent(window, 'mouseup', this._eventHandlers.mouseup);
+            Util.addEvent(c, 'mouseup', this._eventHandlers.mouseup);
+            Util.addEvent(c, 'mousemove', this._eventHandlers.mousemove);
+            Util.addEvent(c, (Util.Engine.gecko) ? 'DOMMouseScroll' : 'mousewheel',
+                          this._eventHandlers.mousewheel);
 
             /* Work around right and middle click browser behaviors */
             Util.addEvent(document, 'click', this._eventHandlers.mousedisable);
@@ -354,19 +347,12 @@ var Keyboard, Mouse;
         ungrab: function () {
             var c = this._target;
 
-            if ('ontouchstart' in document.documentElement) {
-                Util.removeEvent(c, 'touchstart', this._eventHandlers.mousedown);
-                Util.removeEvent(window, 'touchend', this._eventHandlers.mouseup);
-                Util.removeEvent(c, 'touchend', this._eventHandlers.mouseup);
-                Util.removeEvent(c, 'touchmove', this._eventHandlers.mousemove);
-            } else {
-                Util.removeEvent(c, 'mousedown', this._eventHandlers.mousedown);
-                Util.removeEvent(window, 'mouseup', this._eventHandlers.mouseup);
-                Util.removeEvent(c, 'mouseup', this._eventHandlers.mouseup);
-                Util.removeEvent(c, 'mousemove', this._eventHandlers.mousemove);
-                Util.removeEvent(c, (Util.Engine.gecko) ? 'DOMMouseScroll' : 'mousewheel',
-                                 this._eventHandlers.mousewheel);
-            }
+            Util.removeEvent(c, 'mousedown', this._eventHandlers.mousedown);
+            Util.removeEvent(window, 'mouseup', this._eventHandlers.mouseup);
+            Util.removeEvent(c, 'mouseup', this._eventHandlers.mouseup);
+            Util.removeEvent(c, 'mousemove', this._eventHandlers.mousemove);
+            Util.removeEvent(c, (Util.Engine.gecko) ? 'DOMMouseScroll' : 'mousewheel',
+                             this._eventHandlers.mousewheel);
 
             /* Work around right and middle click browser behaviors */
             Util.removeEvent(document, 'click', this._eventHandlers.mousedisable);


### PR DESCRIPTION
Tested in 50.0.2661.94 m (64-bit) on Windows. Loaded noVNC from master (0.5.1)
During the test I tried using the **mouse** to interact with various window elements of a remote machine: *success*.
Interact with various window elements using **touchscreen**: *success*.
My guess is that the following are not supported so these failed to even establish a VNC connection using:
- MS Edge
- Android Chrome
- Android Firefox
- MS IE 11
Hence touch and mouse tests failed on these by default with patch and without.