### PR TITLE
Allow touchmode-interface for Microsoft Surface tablets

### DIFF
--- a/include/ui.js
+++ b/include/ui.js
@@ -53,7 +53,10 @@ var UI;
 
         // Render default UI and initialize settings menu
         start: function(callback) {
-            UI.isTouchDevice = 'ontouchstart' in document.documentElement;
+            UI.isTouchDevice = (('ontouchstart' in window)
+                                // required for MS Surface
+                                || (navigator.maxTouchPoints > 0)
+                                || (navigator.msMaxTouchPoints > 0));
 
             // Stylesheet selection dropdown
             var sheet = WebUtil.selectStylesheet();


### PR DESCRIPTION
We should use navigator.maxTouchPoints since 'ontouchstart' isn't enough to detect touch on MS Surface devices. This had the effect that the touch controls in the UI didn't show on these devices.