### PR TITLE
Split the setDesktopSize function

### DIFF
--- a/include/ui.js
+++ b/include/ui.js
@@ -263,9 +263,9 @@ var UI;
                     UI.resizeTimeout = setTimeout(function(){
                         display.set_maxWidth(size.w);
                         display.set_maxHeight(size.h);
-                        Util.Debug('Attempting setDesktopSize(' +
+                        Util.Debug('Attempting requestDesktopSize(' +
                                    size.w + ', ' + size.h + ')');
-                        UI.rfb.setDesktopSize(size.w, size.h);
+                        UI.rfb.requestDesktopSize(size.w, size.h);
                     }, 500);
                 } else if (scaleType === 'scale' || scaleType === 'downscale') {
                     // use local scaling

--- a/tests/test.rfb.js
+++ b/tests/test.rfb.js
@@ -219,7 +219,7 @@ describe('Remote Frame Buffer Protocol Client', function() {
             });
         });
 
-        describe("#setDesktopSize", function () {
+        describe("#requestDesktopSize", function () {
             beforeEach(function() {
                 client._sock = new Websock();
                 client._sock.open('ws://', 'binary');
@@ -244,19 +244,19 @@ describe('Remote Frame Buffer Protocol Client', function() {
                 expected.push16(2); // height
                 expected.push32(0); // flags
 
-                client.setDesktopSize(1, 2);
+                client.requestDesktopSize(1, 2);
                 expect(client._sock).to.have.sent(new Uint8Array(expected));
             });
 
             it('should not send the request if the client has not recieved a ExtendedDesktopSize rectangle', function () {
                 client._supportsSetDesktopSize = false;
-                client.setDesktopSize(1,2);
+                client.requestDesktopSize(1,2);
                 expect(client._sock.flush).to.not.have.been.called;
             });
 
             it('should not send the request if we are not in a normal state', function () {
                 client._rfb_state = "broken";
-                client.setDesktopSize(1,2);
+                client.requestDesktopSize(1,2);
                 expect(client._sock.flush).to.not.have.been.called;
             });
         });

--- a/vnc_auto.html
+++ b/vnc_auto.html
@@ -92,7 +92,7 @@
                 var controlbarH = $D('noVNC_status_bar').offsetHeight;
                 var padding = 5;
                 if (innerW !== undefined && innerH !== undefined)
-                    rfb.setDesktopSize(innerW, innerH - controlbarH - padding);
+                    rfb.requestDesktopSize(innerW, innerH - controlbarH - padding);
             }
         }
         function FBUComplete(rfb, fbu) {


### PR DESCRIPTION
In order to follow the surrounding coding-standards, the setDesktopSize client message is now split from the public function which now is called requestDesktopSize.