### PR TITLE
Fix for touchscreen devices that also have a mouse.

### DIFF
--- a/include/input.js
+++ b/include/input.js
@@ -338,14 +338,13 @@ var Keyboard, Mouse;
                 Util.addEvent(window, 'touchend', this._eventHandlers.mouseup);
                 Util.addEvent(c, 'touchend', this._eventHandlers.mouseup);
                 Util.addEvent(c, 'touchmove', this._eventHandlers.mousemove);
-            } else {
-                Util.addEvent(c, 'mousedown', this._eventHandlers.mousedown);
-                Util.addEvent(window, 'mouseup', this._eventHandlers.mouseup);
-                Util.addEvent(c, 'mouseup', this._eventHandlers.mouseup);
-                Util.addEvent(c, 'mousemove', this._eventHandlers.mousemove);
-                Util.addEvent(c, (Util.Engine.gecko) ? 'DOMMouseScroll' : 'mousewheel',
-                              this._eventHandlers.mousewheel);
             }
+            Util.addEvent(c, 'mousedown', this._eventHandlers.mousedown);
+            Util.addEvent(window, 'mouseup', this._eventHandlers.mouseup);
+            Util.addEvent(c, 'mouseup', this._eventHandlers.mouseup);
+            Util.addEvent(c, 'mousemove', this._eventHandlers.mousemove);
+            Util.addEvent(c, (Util.Engine.gecko) ? 'DOMMouseScroll' : 'mousewheel',
+                          this._eventHandlers.mousewheel);
 
             /* Work around right and middle click browser behaviors */
             Util.addEvent(document, 'click', this._eventHandlers.mousedisable);
@@ -360,14 +359,13 @@ var Keyboard, Mouse;
                 Util.removeEvent(window, 'touchend', this._eventHandlers.mouseup);
                 Util.removeEvent(c, 'touchend', this._eventHandlers.mouseup);
                 Util.removeEvent(c, 'touchmove', this._eventHandlers.mousemove);
-            } else {
-                Util.removeEvent(c, 'mousedown', this._eventHandlers.mousedown);
-                Util.removeEvent(window, 'mouseup', this._eventHandlers.mouseup);
-                Util.removeEvent(c, 'mouseup', this._eventHandlers.mouseup);
-                Util.removeEvent(c, 'mousemove', this._eventHandlers.mousemove);
-                Util.removeEvent(c, (Util.Engine.gecko) ? 'DOMMouseScroll' : 'mousewheel',
-                                 this._eventHandlers.mousewheel);
             }
+            Util.removeEvent(c, 'mousedown', this._eventHandlers.mousedown);
+            Util.removeEvent(window, 'mouseup', this._eventHandlers.mouseup);
+            Util.removeEvent(c, 'mouseup', this._eventHandlers.mouseup);
+            Util.removeEvent(c, 'mousemove', this._eventHandlers.mousemove);
+            Util.removeEvent(c, (Util.Engine.gecko) ? 'DOMMouseScroll' : 'mousewheel',
+                             this._eventHandlers.mousewheel);
 
             /* Work around right and middle click browser behaviors */
             Util.removeEvent(document, 'click', this._eventHandlers.mousedisable);


### PR DESCRIPTION
Change was tested on:
- touchscreen laptop (touchscreen and mouse for dragging objects, left/right clicking)
- android tablet (was able to drag objects, right click, pan around).

This fix relies on the fact that all touch events once captured are preventing from bubbling hence eliminating the danger of having onmousedown fire right after ontouchstart.

This should solve issue #510 completely.