### PR TITLE
Detect RealVNC's VNC 5.0 Protocol Version

### DIFF
--- a/core/rfb.js
+++ b/core/rfb.js
@@ -670,6 +670,7 @@
                 case "003.008":
                 case "004.000":  // Intel AMT KVM
                 case "004.001":  // RealVNC 4.6
+                case "005.000":  // RealVNC 5.3
                     this._rfb_version = 3.8;
                     break;
                 default:

--- a/tests/test.rfb.js
+++ b/tests/test.rfb.js
@@ -564,6 +564,11 @@ describe('Remote Frame Buffer Protocol Client', function() {
                     expect(client._rfb_version).to.equal(3.8);
                 });
 
+                it('should interpret version 005.000 as version 3.8', function () {
+                    send_ver('005.000', client);
+                    expect(client._rfb_version).to.equal(3.8);
+                });
+
                 it('should fail on an invalid version', function () {
                     send_ver('002.000', client);
                     expect(client._rfb_state).to.equal('failed');


### PR DESCRIPTION
The RFB protocol specifies a max version of 3.8, but RealVNC likes to
increment their version when they add new features.  RealVNC 5.3 sends
"005.000" as the version string, since they've extended their
implementation upon RFB v3.8.  We can detect that, and just tell them we
only speak 3.8, instead of barfing on "005.000" as an invalid version.

Closes #585 