### PR TITLE
Improve rendering/processing delays

### DIFF
--- a/core/display.js
+++ b/core/display.js
@@ -746,10 +746,16 @@
             this._renderQ.push(action);
             if (this._renderQ.length === 1) {
                 // If this can be rendered immediately it will be, otherwise
-                // the scanner will start polling the queue (every
-                // requestAnimationFrame interval)
+                // the scanner will wait for the relevant event
                 this._scan_renderQ();
             }
+        },
+
+        _resume_renderQ: function() {
+            // "this" is the object that is ready, not the
+            // display object
+            this.removeEventListener('load', this._noVNC_display._resume_renderQ);
+            this._noVNC_display._scan_renderQ();
         },
 
         _scan_renderQ: function () {
@@ -776,6 +782,8 @@
                         if (a.img.complete) {
                             this.drawImage(a.img, a.x, a.y);
                         } else {
+                            a.img._noVNC_display = this;
+                            a.img.addEventListener('load', this._resume_renderQ);
                             // We need to wait for this image to 'load'
                             // to keep things in-order
                             ready = false;
@@ -786,10 +794,6 @@
                 if (ready) {
                     this._renderQ.shift();
                 }
-            }
-
-            if (this._renderQ.length > 0) {
-                requestAnimationFrame(this._scan_renderQ.bind(this));
             }
         },
     };

--- a/core/rfb.js
+++ b/core/rfb.js
@@ -1647,10 +1647,6 @@
         return (new DES(passwd)).encrypt(challenge);
     };
 
-    RFB.extract_data_uri = function (arr) {
-        return ";base64," + Base64.encode(arr);
-    };
-
     RFB.encodingHandlers = {
         RAW: function () {
             if (this._FBU.lines === 0) {
@@ -2153,16 +2149,8 @@
 
                     // We have everything, render it
                     this._sock.rQskipBytes(1 + cl_header);  // shift off clt + compact length
-                    var img = new Image();
-                    img.src = "data: image/" + cmode +
-                        RFB.extract_data_uri(this._sock.rQshiftBytes(cl_data));
-                    this._display.renderQ_push({
-                        'type': 'img',
-                        'img': img,
-                        'x': this._FBU.x,
-                        'y': this._FBU.y
-                    });
-                    img = null;
+                    data = this._sock.rQshiftBytes(cl_data);
+                    this._display.imageRect(this._FBU.x, this._FBU.y, "image/" + cmode, data);
                     break;
                 case "filter":
                     var filterId = rQ[rQi + 1];

--- a/core/rfb.js
+++ b/core/rfb.js
@@ -76,6 +76,7 @@
 
     this._sock = null;              // Websock object
     this._display = null;           // Display object
+    this._flushing = false;         // Display flushing state
     this._keyboard = null;          // Keyboard input handler object
     this._mouse = null;             // Mouse input handler object
     this._disconnTimer = null;      // disconnection timer
@@ -185,7 +186,8 @@
     // NB: nothing that needs explicit teardown should be done
     // before this point, since this can throw an exception
     try {
-        this._display = new Display({target: this._target});
+        this._display = new Display({target: this._target,
+                                     onFlush: this._onFlush.bind(this)});
     } catch (exc) {
         Util.Error("Display exception: " + exc);
         throw exc;
@@ -542,7 +544,17 @@
                     Util.Error("Got data while disconnected");
                     break;
                 case 'normal':
-                    while (this._normal_msg() && this._sock.rQlen() > 0);
+                    while (true) {
+                        if (this._flushing) {
+                            break;
+                        }
+                        if (!this._normal_msg()) {
+                            break;
+                        }
+                        if (this._sock.rQlen() === 0) {
+                            break;
+                        }
+                    }
                     break;
                 default:
                     this._init_msg();
@@ -1189,6 +1201,14 @@
             }
         },
 
+        _onFlush: function() {
+            this._flushing = false;
+            // Resume processing
+            if (this._sock.rQlen() > 0) {
+                this._handle_message();
+            }
+        },
+
         _framebufferUpdate: function () {
             var ret = true;
             var now;
@@ -1202,6 +1222,14 @@
                 if (this._timing.fbu_rt_start > 0) {
                     now = (new Date()).getTime();
                     Util.Info("First FBU latency: " + (now - this._timing.fbu_rt_start));
+                }
+
+                // Make sure the previous frame is fully rendered first
+                // to avoid building up an excessive queue
+                if (this._display.pending()) {
+                    this._flushing = true;
+                    this._display.flush();
+                    return false;
                 }
             }
 

--- a/tests/test.display.js
+++ b/tests/test.display.js
@@ -396,13 +396,13 @@ describe('Display/Canvas Helper', function () {
         });
 
         it('should try to process an item when it is pushed on, if nothing else is on the queue', function () {
-            display.renderQ_push({ type: 'noop' });  // does nothing
+            display._renderQ_push({ type: 'noop' });  // does nothing
             expect(display._scan_renderQ).to.have.been.calledOnce;
         });
 
         it('should not try to process an item when it is pushed on if we are waiting for other items', function () {
             display._renderQ.length = 2;
-            display.renderQ_push({ type: 'noop' });
+            display._renderQ_push({ type: 'noop' });
             expect(display._scan_renderQ).to.not.have.been.called;
         });
 
@@ -425,35 +425,35 @@ describe('Display/Canvas Helper', function () {
 
         it('should draw a blit image on type "blit"', function () {
             display.blitImage = sinon.spy();
-            display.renderQ_push({ type: 'blit', x: 3, y: 4, width: 5, height: 6, data: [7, 8, 9] });
+            display._renderQ_push({ type: 'blit', x: 3, y: 4, width: 5, height: 6, data: [7, 8, 9] });
             expect(display.blitImage).to.have.been.calledOnce;
             expect(display.blitImage).to.have.been.calledWith(3, 4, 5, 6, [7, 8, 9], 0);
         });
 
         it('should draw a blit RGB image on type "blitRgb"', function () {
             display.blitRgbImage = sinon.spy();
-            display.renderQ_push({ type: 'blitRgb', x: 3, y: 4, width: 5, height: 6, data: [7, 8, 9] });
+            display._renderQ_push({ type: 'blitRgb', x: 3, y: 4, width: 5, height: 6, data: [7, 8, 9] });
             expect(display.blitRgbImage).to.have.been.calledOnce;
             expect(display.blitRgbImage).to.have.been.calledWith(3, 4, 5, 6, [7, 8, 9], 0);
         });
 
         it('should copy a region on type "copy"', function () {
             display.copyImage = sinon.spy();
-            display.renderQ_push({ type: 'copy', x: 3, y: 4, width: 5, height: 6, old_x: 7, old_y: 8 });
+            display._renderQ_push({ type: 'copy', x: 3, y: 4, width: 5, height: 6, old_x: 7, old_y: 8 });
             expect(display.copyImage).to.have.been.calledOnce;
             expect(display.copyImage).to.have.been.calledWith(7, 8, 3, 4, 5, 6);
         });
 
         it('should fill a rect with a given color on type "fill"', function () {
             display.fillRect = sinon.spy();
-            display.renderQ_push({ type: 'fill', x: 3, y: 4, width: 5, height: 6, color: [7, 8, 9]});
+            display._renderQ_push({ type: 'fill', x: 3, y: 4, width: 5, height: 6, color: [7, 8, 9]});
             expect(display.fillRect).to.have.been.calledOnce;
             expect(display.fillRect).to.have.been.calledWith(3, 4, 5, 6, [7, 8, 9]);
         });
 
         it('should draw an image from an image object on type "img" (if complete)', function () {
             display.drawImage = sinon.spy();
-            display.renderQ_push({ type: 'img', x: 3, y: 4, img: { complete: true } });
+            display._renderQ_push({ type: 'img', x: 3, y: 4, img: { complete: true } });
             expect(display.drawImage).to.have.been.calledOnce;
             expect(display.drawImage).to.have.been.calledWith({ complete: true }, 3, 4);
         });

--- a/tests/test.rfb.js
+++ b/tests/test.rfb.js
@@ -1200,7 +1200,7 @@ describe('Remote Frame Buffer Protocol Client', function() {
                 client._sock._websocket._receive_data(new Uint8Array([0, 0, 0, 3]));
                 expect(client._sock._websocket._get_sent_data()).to.have.length(0);
 
-                client._framebufferUpdate = function () { return true; };  // we magically have enough data
+                client._framebufferUpdate = function () { this._sock.rQskip8(); return true; };  // we magically have enough data
                 // 247 should *not* be used as the message type here
                 client._sock._websocket._receive_data(new Uint8Array([247]));
                 expect(client._sock).to.have.sent(expected_msg._sQ);
@@ -2002,14 +2002,12 @@ describe('Remote Frame Buffer Protocol Client', function() {
                 expect(client._init_msg).to.have.been.calledOnce;
             });
 
-            it('should split up the handling of muplitle normal messages across 10ms intervals', function () {
+            it('should process all normal messages directly', function () {
                 client.connect('host', 8675);
                 client._sock._websocket._open();
                 client._rfb_state = 'normal';
                 client.set_onBell(sinon.spy());
                 client._sock._websocket._receive_data(new Uint8Array([0x02, 0x02]));
-                expect(client.get_onBell()).to.have.been.calledOnce;
-                this.clock.tick(20);
                 expect(client.get_onBell()).to.have.been.calledTwice;
             });
 


### PR DESCRIPTION
This resolves some rendering delays that we were seeing. Three issues resolved:

 - setTimeout(foo, 0) does not trigger right away. The spec mandates >4 ms, and some browsers have more. This delay is a practical problem for some small messages (like Fence).

 - requestAnimationFrame() triggers at 17 ms or worse. There is a proper event for waiting on an image to load.

 - Firefox has excessive delays in rendering images[1]. To avoid this and similar issues to create a massive rendering queue, limit the queue to one update.

[1] https://bugzilla.mozilla.org/show_bug.cgi?id=1304391