### PR TITLE
Don't send Unicode as keysym

### DIFF
--- a/app/ui.js
+++ b/app/ui.js
@@ -14,6 +14,7 @@
 /* [module]
  * import Util from "../core/util";
  * import KeyTable from "../core/input/keysym";
+ * import keysyms from "./keysymdef";
  * import RFB from "../core/rfb";
  * import Display from "../core/display";
  * import WebUtil from "./webutil";
@@ -1411,7 +1412,7 @@ var UI;
                 UI.rfb.sendKey(KeyTable.XK_BackSpace);
             }
             for (i = newLen - inputs; i < newLen; i++) {
-                UI.rfb.sendKey(newValue.charCodeAt(i));
+                UI.rfb.sendKey(keysyms.fromUnicode(newValue.charCodeAt(i)).keysym);
             }
 
             // Control the text content length in the keyboardinput element

--- a/core/input/keysymdef.js
+++ b/core/input/keysymdef.js
@@ -10,7 +10,13 @@ var keysyms = (function(){
 
     function lookup(k) { return k ? {keysym: k, keyname: keynames ? keynames[k] : k} : undefined; }
     return {
-        fromUnicode : function(u) { return lookup(codepoints[u]); },
+        fromUnicode : function(u) {
+            var keysym = codepoints[u];
+            if (keysym === undefined) {
+                keysym = 0x01000000 | u;
+            }
+            return lookup(keysym);
+        },
         lookup : lookup
     };
 })();

--- a/core/input/util.js
+++ b/core/input/util.js
@@ -184,10 +184,7 @@ var KeyboardUtil = {};
             codepoint = evt.keyCode;
         }
         if (codepoint) {
-            var res = keysyms.fromUnicode(substituteCodepoint(codepoint));
-            if (res) {
-                return res;
-            }
+            return keysyms.fromUnicode(substituteCodepoint(codepoint));
         }
         // we could check evt.key here.
         // Legal values are defined in http://www.w3.org/TR/DOM-Level-3-Events/#key-values-list,

--- a/core/rfb.js
+++ b/core/rfb.js
@@ -318,15 +318,15 @@
 
         // Send a key press. If 'down' is not specified then send a down key
         // followed by an up key.
-        sendKey: function (code, down) {
+        sendKey: function (keysym, down) {
             if (this._rfb_connection_state !== 'connected' || this._view_only) { return false; }
             if (typeof down !== 'undefined') {
-                Util.Info("Sending key code (" + (down ? "down" : "up") + "): " + code);
-                RFB.messages.keyEvent(this._sock, code, down ? 1 : 0);
+                Util.Info("Sending keysym (" + (down ? "down" : "up") + "): " + keysym);
+                RFB.messages.keyEvent(this._sock, keysym, down ? 1 : 0);
             } else {
-                Util.Info("Sending key code (down + up): " + code);
-                RFB.messages.keyEvent(this._sock, code, 1);
-                RFB.messages.keyEvent(this._sock, code, 0);
+                Util.Info("Sending keysym (down + up): " + keysym);
+                RFB.messages.keyEvent(this._sock, keysym, 1);
+                RFB.messages.keyEvent(this._sock, keysym, 0);
             }
             return true;
         },

--- a/tests/test.helper.js
+++ b/tests/test.helper.js
@@ -38,9 +38,9 @@ describe('Helpers', function() {
         it('should map characters which aren\'t in Latin1 *or* Windows-1252 to keysyms', function() {
             expect(keysyms.fromUnicode('ŵ'.charCodeAt())).to.have.property('keysym', 0x1000175);
         });
-        it('should return undefined for unknown codepoints', function() {
-            expect(keysyms.fromUnicode('\n'.charCodeAt())).to.be.undefined;
-            expect(keysyms.fromUnicode('\u1F686'.charCodeAt())).to.be.undefined;
+        it('should map unknown codepoints to the Unicode range', function() {
+            expect(keysyms.fromUnicode('\n'.charCodeAt())).to.have.property('keysym', 0x100000a);
+            expect(keysyms.fromUnicode('\u{1F686}'.charCodeAt())).to.have.property('keysym', 0x101f686);
         });
     });
 

--- a/utils/parse.js
+++ b/utils/parse.js
@@ -87,7 +87,13 @@ var out = "// This file describes mappings from Unicode codepoints to the keysym
 "\n" +
 "    function lookup(k) { return k ? {keysym: k, keyname: keynames ? keynames[k] : k} : undefined; }\n" +
 "    return {\n" +
-"        fromUnicode : function(u) { return lookup(codepoints[u]); },\n" +
+"        fromUnicode : function(u) {\n" +
+"            var keysym = codepoints[u];\n" +
+"            if (keysym === undefined) {\n" +
+"                keysym = 0x01000000 | u;\n" +
+"            }\n" +
+"            return lookup(keysym);\n" +
+"        },\n" +
 "        lookup : lookup\n" +
 "    };\n" +
 "})();\n";


### PR DESCRIPTION
We had a bug where we would send a Unicode codepoint as a keysym to the server. This of course ended up with a completely wrong symbol.

Also made sure we can transfer the entire Unicode range.
