### PR TITLE
Display double buffering

### DIFF
--- a/app/ui.js
+++ b/app/ui.js
@@ -1107,11 +1107,6 @@ var UI;
                     // is finished we wait 0.5 seconds before sending the request.
                     clearTimeout(UI.resizeTimeout);
                     UI.resizeTimeout = setTimeout(function(){
-
-                        // Limit the viewport to the size of the browser window
-                        display.set_maxWidth(screen.w);
-                        display.set_maxHeight(screen.h);
-
                         // Request a remote size covering the viewport
                         if (UI.rfb.requestDesktopSize(screen.w, screen.h)) {
                             Util.Debug('Requested new desktop size: ' +
@@ -1192,8 +1187,6 @@ var UI;
             if (new_clip && size) {
                 // When clipping is enabled, the screen is limited to
                 // the size of the browser window.
-                display.set_maxWidth(size.w);
-                display.set_maxHeight(size.h);
 
                 var screen = document.getElementById('noVNC_screen');
                 var canvas = document.getElementById('noVNC_canvas');
@@ -1209,9 +1202,6 @@ var UI;
 
                 display.viewportChangeSize(new_w, size.h);
             } else {
-                // Disable max dimensions
-                display.set_maxWidth(0);
-                display.set_maxHeight(0);
                 display.viewportChangeSize();
             }
         },

--- a/app/ui.js
+++ b/app/ui.js
@@ -1187,22 +1187,7 @@ var UI;
             if (new_clip && size) {
                 // When clipping is enabled, the screen is limited to
                 // the size of the browser window.
-
-                var screen = document.getElementById('noVNC_screen');
-                var canvas = document.getElementById('noVNC_canvas');
-
-                // Hide potential scrollbars that can skew the position
-                screen.style.overflow = "hidden";
-
-                // The x position marks the left margin of the canvas,
-                // remove the margin from both sides to keep it centered.
-                var new_w = size.w - (2 * Util.getPosition(canvas).x);
-
-                screen.style.overflow = "visible";
-
-                display.viewportChangeSize(new_w, size.h);
-            } else {
-                display.viewportChangeSize();
+                display.viewportChangeSize(size.w, size.h);
             }
         },
 

--- a/app/ui.js
+++ b/app/ui.js
@@ -343,7 +343,7 @@ var UI;
                                   'onClipboard': UI.clipboardReceive,
                                   'onBell': UI.bell,
                                   'onFBUComplete': UI.initialResize,
-                                  'onFBResize': UI.updateViewDrag,
+                                  'onFBResize': UI.updateSessionSize,
                                   'onDesktopName': UI.updateDesktopName});
                 return true;
             } catch (exc) {
@@ -1574,6 +1574,11 @@ var UI;
                 UI.rfb.get_keyboard().set_focused(true);
                 UI.rfb.get_mouse().set_focused(true);
             }
+        },
+
+        updateSessionSize: function(rfb, width, height) {
+            UI.updateViewClip();
+            UI.updateViewDrag();
         },
 
         updateDesktopName: function(rfb, name) {

--- a/core/display.js
+++ b/core/display.js
@@ -26,10 +26,6 @@
     this._fb_width = 0;
     this._fb_height = 0;
 
-    // the size limit of the viewport (start disabled)
-    this._maxWidth = 0;
-    this._maxHeight = 0;
-
     // the visible "physical canvas" viewport
     this._viewportLoc = { 'x': 0, 'y': 0, 'w': 0, 'h': 0 };
 
@@ -169,16 +165,6 @@
 
             var vp = this._viewportLoc;
             if (vp.w !== width || vp.h !== height) {
-
-                if (this._viewport) {
-                    if (this._maxWidth !== 0 && width > this._maxWidth) {
-                        width = this._maxWidth;
-                    }
-                    if (this._maxHeight !== 0 && height > this._maxHeight) {
-                        height = this._maxHeight;
-                    }
-                }
-
                 vp.w = width;
                 vp.h = height;
 
@@ -553,16 +539,7 @@
 
         clippingDisplay: function () {
             var vp = this._viewportLoc;
-
-            var fbClip = this._fb_width > vp.w || this._fb_height > vp.h;
-            var limitedVp = this._maxWidth !== 0 && this._maxHeight !== 0;
-            var clipping = false;
-
-            if (limitedVp) {
-                clipping = vp.w > this._maxWidth || vp.h > this._maxHeight;
-            }
-
-            return fbClip || (limitedVp && clipping);
+            return this._fb_width > vp.w || this._fb_height > vp.h;
         },
 
         // Overridden getters/setters
@@ -616,21 +593,9 @@
         // Private Methods
         _rescale: function (factor) {
             this._scale = factor;
-
-            var w;
-            var h;
-
-            if (this._viewport &&
-                this._maxWidth !== 0 && this._maxHeight !== 0) {
-                w = Math.min(this._fb_width, this._maxWidth);
-                h = Math.min(this._fb_height, this._maxHeight);
-            } else {
-                w = this._fb_width;
-                h = this._fb_height;
-            }
-
-            this._target.style.width = Math.round(factor * w) + 'px';
-            this._target.style.height = Math.round(factor * h) + 'px';
+            var vp = this._viewportLoc;
+            this._target.style.width = Math.round(factor * vp.w) + 'px';
+            this._target.style.height = Math.round(factor * vp.h) + 'px';
         },
 
         _setFillColor: function (color) {
@@ -776,8 +741,6 @@
         ['viewport', 'rw', 'bool'],    // Use viewport clipping
         ['width', 'ro', 'int'],        // Display area width
         ['height', 'ro', 'int'],       // Display area height
-        ['maxWidth', 'rw', 'int'],     // Viewport max width (0 if disabled)
-        ['maxHeight', 'rw', 'int'],    // Viewport max height (0 if disabled)
 
         ['render_mode', 'ro', 'str'],  // Canvas rendering mode (read-only)
 

--- a/core/display.js
+++ b/core/display.js
@@ -566,23 +566,12 @@
         },
 
         // Overridden getters/setters
-        get_context: function () {
-            return this._drawCtx;
-        },
-
         set_scale: function (scale) {
             this._rescale(scale);
         },
 
-        set_width: function (w) {
-            this._fb_width = w;
-        },
         get_width: function () {
             return this._fb_width;
-        },
-
-        set_height: function (h) {
-            this._fb_height =  h;
         },
         get_height: function () {
             return this._fb_height;
@@ -785,8 +774,8 @@
         ['colourMap', 'rw', 'arr'],    // Colour map array (when not true-color)
         ['scale', 'rw', 'float'],      // Display area scale factor 0.0 - 1.0
         ['viewport', 'rw', 'bool'],    // Use viewport clipping
-        ['width', 'rw', 'int'],        // Display area width
-        ['height', 'rw', 'int'],       // Display area height
+        ['width', 'ro', 'int'],        // Display area width
+        ['height', 'ro', 'int'],       // Display area height
         ['maxWidth', 'rw', 'int'],     // Viewport max width (0 if disabled)
         ['maxHeight', 'rw', 'int'],    // Viewport max height (0 if disabled)
 

--- a/core/display.js
+++ b/core/display.js
@@ -350,7 +350,7 @@
         clear: function () {
             if (this._logo) {
                 this.resize(this._logo.width, this._logo.height);
-                this.blitStringImage(this._logo.data, 0, 0);
+                this.imageRect(0, 0, this._logo.type, this._logo.data);
             } else {
                 if (Util.Engine.trident === 6) {
                     // NB(directxman12): there's a bug in IE10 where we can fail to actually
@@ -561,15 +561,6 @@
             } else {
                 this._rgbxImageData(x, y, this._viewportLoc.x, this._viewportLoc.y, width, height, arr, offset);
             }
-        },
-
-        blitStringImage: function (str, x, y) {
-            var img = new Image();
-            img.onload = function () {
-                this._drawCtx.drawImage(img, x - this._viewportLoc.x, y - this._viewportLoc.y);
-            }.bind(this);
-            img.src = str;
-            return img; // for debugging purposes
         },
 
         // wrap ctx.drawImage but relative to viewport
@@ -820,7 +811,7 @@
     Util.make_properties(Display, [
         ['target', 'wo', 'dom'],       // Canvas element for rendering
         ['context', 'ro', 'raw'],      // Canvas 2D context for rendering (read-only)
-        ['logo', 'rw', 'raw'],         // Logo to display when cleared: {"width": w, "height": h, "data": data}
+        ['logo', 'rw', 'raw'],         // Logo to display when cleared: {"width": w, "height": h, "type": mime-type, "data": data}
         ['true_color', 'rw', 'bool'],  // Use true-color pixel data
         ['colourMap', 'rw', 'arr'],    // Colour map array (when not true-color)
         ['scale', 'rw', 'float'],      // Display area scale factor 0.0 - 1.0

--- a/tests/assertions.js
+++ b/tests/assertions.js
@@ -2,7 +2,8 @@
 chai.use(function (_chai, utils) {
     _chai.Assertion.addMethod('displayed', function (target_data) {
         var obj = this._obj;
-        var data_cl = obj._drawCtx.getImageData(0, 0, obj._viewportLoc.w, obj._viewportLoc.h).data;
+        var ctx = obj._target.getContext('2d');
+        var data_cl = ctx.getImageData(0, 0, obj._target.width, obj._target.height).data;
         // NB(directxman12): PhantomJS 1.x doesn't implement Uint8ClampedArray, so work around that
         var data = new Uint8Array(data_cl);
         var same = true;

--- a/tests/playback.js
+++ b/tests/playback.js
@@ -37,6 +37,7 @@ enable_test_mode = function () {
 
 next_iteration = function () {
     rfb = new RFB({'target': document.getElementById('VNC_canvas'),
+                   'view_only': true,
                    'onDisconnected': disconnected,
                    'onNotification': notification});
     enable_test_mode();

--- a/tests/playback.js
+++ b/tests/playback.js
@@ -30,13 +30,15 @@ enable_test_mode = function () {
         this._rfb_password = (password !== undefined) ? password : "";
         this._rfb_path = (path !== undefined) ? path : "";
         this._sock.init('binary', 'ws');
-        this._updateState('ProtocolVersion', "Starting VNC handshake");
+        this._rfb_connection_state = 'connecting';
+        this._rfb_init_state = 'ProtocolVersion';
     };
 };
 
 next_iteration = function () {
     rfb = new RFB({'target': document.getElementById('VNC_canvas'),
-                   'onUpdateState': updateState});
+                   'onDisconnected': disconnected,
+                   'onNotification': notification});
     enable_test_mode();
 
     // Missing in older recordings

--- a/tests/test.display.js
+++ b/tests/test.display.js
@@ -83,10 +83,10 @@ describe('Display/Canvas Helper', function () {
             expect(display).to.have.displayed(expected);
         });
 
-        if('should resize the target canvas when resizing the viewport', function() {
+        it('should resize the target canvas when resizing the viewport', function() {
             display.viewportChangeSize(2, 2);
-            expect(canvas.width).to.equal(2);
-            expect(canvas.height).to.equal(2);
+            expect(display._target.width).to.equal(2);
+            expect(display._target.height).to.equal(2);
         });
 
         it('should redraw when moving the viewport', function () {
@@ -100,39 +100,16 @@ describe('Display/Canvas Helper', function () {
             display.viewportChangeSize(2, 2);
             expect(display.flip).to.have.been.calledOnce;
         });
-    });
 
-    describe('clipping', function () {
-        var display;
-        beforeEach(function () {
-            display = new Display({ target: document.createElement('canvas'), prefer_js: false, viewport: true });
-            display.resize(4, 3);
-        });
-
-        it('should report true when no max-size and framebuffer > viewport', function () {
-            display.viewportChangeSize(2,2);
+        it('should report clipping when framebuffer > viewport', function () {
             var clipping = display.clippingDisplay();
             expect(clipping).to.be.true;
         });
 
-        it('should report false when no max-size and framebuffer = viewport', function () {
+        it('should report not clipping when framebuffer = viewport', function () {
+            display.viewportChangeSize(5, 5);
             var clipping = display.clippingDisplay();
             expect(clipping).to.be.false;
-        });
-
-        it('should report true when viewport > max-size and framebuffer > viewport', function () {
-            display.viewportChangeSize(2,2);
-            display.set_maxWidth(1);
-            display.set_maxHeight(2);
-            var clipping = display.clippingDisplay();
-            expect(clipping).to.be.true;
-        });
-
-        it('should report true when viewport > max-size and framebuffer = viewport', function () {
-            display.set_maxWidth(1);
-            display.set_maxHeight(2);
-            var clipping = display.clippingDisplay();
-            expect(clipping).to.be.true;
         });
     });
 

--- a/tests/test.display.js
+++ b/tests/test.display.js
@@ -425,6 +425,14 @@ describe('Display/Canvas Helper', function () {
             expect(img.addEventListener).to.have.been.calledOnce;
         });
 
+        it('should call callback when queue is flushed', function () {
+            display.set_onFlush(sinon.spy());
+            display.fillRect(0, 0, 4, 4, [0, 0xff, 0]);
+            expect(display.get_onFlush()).to.not.have.been.called;
+            display.flush();
+            expect(display.get_onFlush()).to.have.been.calledOnce;
+        });
+
         it('should draw a blit image on type "blit"', function () {
             display.blitImage = sinon.spy();
             display._renderQ_push({ type: 'blit', x: 3, y: 4, width: 5, height: 6, data: [7, 8, 9] });

--- a/tests/test.display.js
+++ b/tests/test.display.js
@@ -71,8 +71,7 @@ describe('Display/Canvas Helper', function () {
         });
 
         it('should take viewport location into consideration when drawing images', function () {
-            display.set_width(4);
-            display.set_height(4);
+            display.resize(4, 4);
             display.viewportChangeSize(2, 2);
             display.drawImage(make_image_canvas(basic_data), 1, 1);
             display.flip();

--- a/tests/test.rfb.js
+++ b/tests/test.rfb.js
@@ -1368,14 +1368,11 @@ describe('Remote Frame Buffer Protocol Client', function() {
                 client._fb_width = 4;
                 client._fb_height = 4;
                 client._display.resize(4, 4);
-                var initial_data = client._display._drawCtx.createImageData(4, 2);
-                var initial_data_arr = target_data_check_arr.slice(0, 32);
-                for (var i = 0; i < 32; i++) { initial_data.data[i] = initial_data_arr[i]; }
-                client._display._drawCtx.putImageData(initial_data, 0, 0);
+                client._display.blitRgbxImage(0, 0, 4, 2, new Uint8Array(target_data_check_arr.slice(0, 32)), 0);
 
                 var info = [{ x: 0, y: 2, width: 2, height: 2, encoding: 0x01},
                             { x: 2, y: 2, width: 2, height: 2, encoding: 0x01}];
-                // data says [{ old_x: 0, old_y: 0 }, { old_x: 0, old_y: 0 }]
+                // data says [{ old_x: 2, old_y: 0 }, { old_x: 0, old_y: 0 }]
                 var rects = [[0, 2, 0, 0], [0, 0, 0, 0]];
                 send_fbu_msg([info[0]], [rects[0]], client, 2);
                 send_fbu_msg([info[1]], [rects[1]], client, -1);
@@ -1394,10 +1391,7 @@ describe('Remote Frame Buffer Protocol Client', function() {
                     // a really small frame
                     client._fb_width = 4;
                     client._fb_height = 4;
-                    client._display._fb_width = 4;
-                    client._display._fb_height = 4;
-                    client._display._viewportLoc.w = 4;
-                    client._display._viewportLoc.h = 4;
+                    client._display.resize(4, 4);
                     client._fb_Bpp = 4;
                 });
 
@@ -1418,10 +1412,7 @@ describe('Remote Frame Buffer Protocol Client', function() {
 
                 it('should handle the COPYRECT encoding', function () {
                     // seed some initial data to copy
-                    var initial_data = client._display._drawCtx.createImageData(4, 2);
-                    var initial_data_arr = target_data_check_arr.slice(0, 32);
-                    for (var i = 0; i < 32; i++) { initial_data.data[i] = initial_data_arr[i]; }
-                    client._display._drawCtx.putImageData(initial_data, 0, 0);
+                    client._display.blitRgbxImage(0, 0, 4, 2, new Uint8Array(target_data_check_arr.slice(0, 32)), 0);
 
                     var info = [{ x: 0, y: 2, width: 2, height: 2, encoding: 0x01},
                                 { x: 2, y: 2, width: 2, height: 2, encoding: 0x01}];
@@ -1471,10 +1462,7 @@ describe('Remote Frame Buffer Protocol Client', function() {
                         // a really small frame
                         client._fb_width = 4;
                         client._fb_height = 4;
-                        client._display._fb_width = 4;
-                        client._display._fb_height = 4;
-                        client._display._viewportLoc.w = 4;
-                        client._display._viewportLoc.h = 4;
+                        client._display.resize(4, 4);
                         client._fb_Bpp = 4;
                     });
 
@@ -1525,8 +1513,7 @@ describe('Remote Frame Buffer Protocol Client', function() {
                     it('should handle a tile with only bg specified and an empty frame afterwards', function () {
                         // set the width so we can have two tiles
                         client._fb_width = 8;
-                        client._display._fb_width = 8;
-                        client._display._viewportLoc.w = 8;
+                        client._display.resize(8, 4);
 
                         var info = [{ x: 0, y: 0, width: 32, height: 4, encoding: 0x05 }];
 
@@ -1649,10 +1636,7 @@ describe('Remote Frame Buffer Protocol Client', function() {
                         // a really small frame
                         client._fb_width = 4;
                         client._fb_height = 4;
-                        client._display._fb_width = 4;
-                        client._display._fb_height = 4;
-                        client._display._viewportLoc.w = 4;
-                        client._display._viewportLoc.h = 4;
+                        client._display.resize(4, 4);
                         client._fb_Bpp = 4;
                         sinon.spy(client._display, 'resize');
                         client.set_onFBResize(sinon.spy());

--- a/tests/vnc_perf.html
+++ b/tests/vnc_perf.html
@@ -74,23 +74,18 @@
             }
         }
 
-        updateState = function (rfb, state, oldstate, mesg) {
-            switch (state) {
-                case 'failed':
-                case 'fatal':
-                    msg("noVNC sent '" + state +
-                        "' state during pass " + pass +
-                        ", iteration " + iteration +
-                        " frame " + frame_idx);
-                    test_state = 'failed';
-                    break;
-                case 'loaded':
-                    document.getElementById('startButton').disabled = false;
-                    break;
+        disconnected = function (rfb, reason) {
+            if (reason) {
+                msg("noVNC sent '" + state +
+                    "' state during pass " + pass +
+                    ", iteration " + iteration +
+                    " frame " + frame_idx);
+                test_state = 'failed';
             }
-            if (typeof mesg !== 'undefined') {
-                document.getElementById('VNC_status').innerHTML = mesg;
-            }
+        }
+
+        notification = function (rfb, mesg, level, options) {
+            document.getElementById('VNC_status').innerHTML = mesg;
         }
 
         function do_test() {

--- a/tests/vnc_playback.html
+++ b/tests/vnc_playback.html
@@ -68,19 +68,15 @@
             message("Must specify data=FOO in query string.");
         }
 
-        updateState = function (rfb, state, oldstate, msg) {
-            switch (state) {
-                case 'failed':
-                case 'fatal':
-                    message("noVNC sent '" + state + "' state during iteration " + iteration + " frame " + frame_idx);
-                    test_state = 'failed';
-                    break;
-                case 'loaded':
-                    break;
+        disconnected = function (rfb, reason) {
+            if (reason) {
+                message("noVNC sent '" + state + "' state during iteration " + iteration + " frame " + frame_idx);
+                test_state = 'failed';
             }
-            if (typeof msg !== 'undefined') {
-                document.getElementById('VNC_status').innerHTML = msg;
-            }
+        }
+
+        notification = function (rfb, mesg, level, options) {
+            document.getElementById('VNC_status').innerHTML = mesg;
         }
 
         function start() {


### PR DESCRIPTION
Do all rendering to a hidden canvas and then copy over the finished frame to the visible canvas once everything is done. This simplifies things and solves some bugs as we can retain a copy of the entire
frame buffer.

Tested on Chrome and Firefox. Performance is roughly the same after these changes, so no gain there unfortunately. But it makes panning behave very nicely and it allows for more fun stuff with panning and zooming in the future.
